### PR TITLE
Add household methods to get costs for insulation elements

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -1,7 +1,9 @@
 import datetime
 import math
 import random
-from typing import Set
+from typing import Dict, Set
+
+import pandas as pd
 
 from abm import Agent
 from simulation.constants import (
@@ -17,9 +19,20 @@ from simulation.constants import (
     Epc,
     HeatingFuel,
     HeatingSystem,
+    InsulationSegment,
     OccupantType,
     PropertyType,
 )
+from simulation.costs import (
+    CAVITY_WALL_INSULATION_COST,
+    DOUBLE_GLAZING_UPVC_COST,
+    INTERNAL_WALL_INSULATION_COST,
+    LOFT_INSULATION_JOISTS_COST,
+)
+
+
+def sample_interval_uniformly(interval: pd.Interval) -> float:
+    return random.randint(interval.left, interval.right)
 
 
 class Household(Agent):
@@ -112,6 +125,48 @@ class Household(Agent):
             self.wealth_percentile,
         )
 
+    @property
+    def insulation_segment(self) -> InsulationSegment:
+        # As per the property segmentation used in BEIS - WHAT DOES IT COST TO RETROFIT HOMES?
+
+        if self.property_type == PropertyType.FLAT:
+            if self.floor_area_sqm < 54:
+                return InsulationSegment.SMALL_FLAT
+            return InsulationSegment.LARGE_FLAT
+
+        if (
+            self.property_type == PropertyType.HOUSE
+            and self.built_form == BuiltForm.MID_TERRACE
+        ):
+            return (
+                InsulationSegment.SMALL_MID_TERRACE_HOUSE
+                if self.floor_area_sqm < 76
+                else InsulationSegment.LARGE_MID_TERRACE_HOUSE
+            )
+
+        if self.property_type == PropertyType.HOUSE and self.built_form in [
+            BuiltForm.END_TERRACE,
+            BuiltForm.SEMI_DETACHED,
+        ]:
+            return (
+                InsulationSegment.SMALL_SEMI_END_TERRACE_HOUSE
+                if self.floor_area_sqm < 80
+                else InsulationSegment.LARGE_SEMI_END_TERRACE_HOUSE
+            )
+
+        if (
+            self.property_type == PropertyType.HOUSE
+            and self.built_form == BuiltForm.DETACHED
+        ):
+            return (
+                InsulationSegment.SMALL_DETACHED_HOUSE
+                if self.floor_area_sqm < 117
+                else InsulationSegment.LARGE_DETACHED_HOUSE
+            )
+
+        if self.property_type == PropertyType.BUNGALOW:
+            return InsulationSegment.BUNGALOW
+
     def evaluate_renovation(self, model) -> None:
 
         step_interval_years = model.step_interval / datetime.timedelta(days=365)
@@ -151,7 +206,32 @@ class Household(Agent):
             ]
         )
 
+    def get_quote_insulation_elements(
+        self, elements: Set[Element]
+    ) -> Dict[Element, float]:
+
+        insulation_quotes = {element: 0 for element in elements}
+        for element in elements:
+            if element == Element.WALLS:
+                if self.is_solid_wall:
+                    cost_range = INTERNAL_WALL_INSULATION_COST[self.insulation_segment]
+                    insulation_quotes[element] = sample_interval_uniformly(cost_range)
+                else:
+                    cost_range = CAVITY_WALL_INSULATION_COST[self.insulation_segment]
+                    insulation_quotes[element] = sample_interval_uniformly(cost_range)
+            if element == Element.GLAZING:
+                cost_range = DOUBLE_GLAZING_UPVC_COST[self.insulation_segment]
+                insulation_quotes[element] = sample_interval_uniformly(cost_range)
+            if element == Element.ROOF:
+                cost_range = LOFT_INSULATION_JOISTS_COST[self.insulation_segment]
+                insulation_quotes[element] = sample_interval_uniformly(cost_range)
+
+        return insulation_quotes
+
     def step(self, model):
         self.evaluate_renovation(model)
         if self.is_renovating:
             self.decide_renovation_scope()
+            if self.renovate_insulation:
+                upgradable_elements = self.get_upgradable_insulation_elements()
+                self.get_quote_insulation_elements(upgradable_elements)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -189,19 +189,19 @@ class Household(Agent):
     def get_upgradable_insulation_elements(self) -> Set[Element]:
 
         measures_and_grades = zip(
+            [Element.WALLS, Element.ROOF, Element.GLAZING],
             [
                 self.walls_energy_efficiency,
                 self.roof_energy_efficiency,
                 self.windows_energy_efficiency,
             ],
-            [Element.WALLS, Element.ROOF, Element.GLAZING],
         )
 
         MAX_ENERGY_EFFICIENCY_SCORE = 5
         return set(
             [
                 measure
-                for grade, measure in measures_and_grades
+                for measure, grade in measures_and_grades
                 if grade < MAX_ENERGY_EFFICIENCY_SCORE
             ]
         )

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -198,13 +198,11 @@ class Household(Agent):
         )
 
         MAX_ENERGY_EFFICIENCY_SCORE = 5
-        return set(
-            [
-                measure
-                for measure, grade in measures_and_grades
-                if grade < MAX_ENERGY_EFFICIENCY_SCORE
-            ]
-        )
+        return {
+            measure
+            for measure, grade in measures_and_grades
+            if grade < MAX_ENERGY_EFFICIENCY_SCORE
+        }
 
     def get_quote_insulation_elements(
         self, elements: Set[Element]

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -1,6 +1,7 @@
 import datetime
 import math
 import random
+from typing import Set
 
 from abm import Agent
 from simulation.constants import (
@@ -12,6 +13,7 @@ from simulation.constants import (
     HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
+    Element,
     Epc,
     HeatingFuel,
     HeatingSystem,
@@ -128,6 +130,26 @@ class Household(Agent):
             PROBA_HEATING_SYSTEM_UPDATE
         )
         self.renovate_insulation = self.true_with_probability(PROBA_INSULATION_UPDATE)
+
+    def get_upgradable_insulation_elements(self) -> Set[Element]:
+
+        measures_and_grades = zip(
+            [
+                self.walls_energy_efficiency,
+                self.roof_energy_efficiency,
+                self.windows_energy_efficiency,
+            ],
+            [Element.WALLS, Element.ROOF, Element.GLAZING],
+        )
+
+        MAX_ENERGY_EFFICIENCY_SCORE = 5
+        return set(
+            [
+                measure
+                for grade, measure in measures_and_grades
+                if grade < MAX_ENERGY_EFFICIENCY_SCORE
+            ]
+        )
 
     def step(self, model):
         self.evaluate_renovation(model)

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -76,3 +76,9 @@ GB_RENOVATION_BUDGET_WEIBULL_BETA = 21_994
 # A distribution aligned to Q2 2021 GB property values
 GB_PROPERTY_VALUE_WEIBULL_ALPHA = 1.61
 GB_PROPERTY_VALUE_WEIBULL_BETA = 280_000
+
+
+class Element(enum.Enum):
+    ROOF = 0
+    GLAZING = 1
+    WALLS = 2

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -82,3 +82,15 @@ class Element(enum.Enum):
     ROOF = 0
     GLAZING = 1
     WALLS = 2
+
+
+class InsulationSegment(enum.Enum):
+    SMALL_FLAT = 0
+    LARGE_FLAT = 1
+    SMALL_MID_TERRACE_HOUSE = 2
+    LARGE_MID_TERRACE_HOUSE = 3
+    SMALL_SEMI_END_TERRACE_HOUSE = 4
+    LARGE_SEMI_END_TERRACE_HOUSE = 5
+    SMALL_DETACHED_HOUSE = 6
+    LARGE_DETACHED_HOUSE = 7
+    BUNGALOW = 8

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -1,0 +1,53 @@
+import pandas as pd
+
+from simulation.constants import InsulationSegment
+
+# Source: BEIS - WHAT DOES IT COST TO RETROFIT HOMES?
+
+CAVITY_WALL_INSULATION_COST = {
+    InsulationSegment.SMALL_FLAT: pd.Interval(300, 630),
+    InsulationSegment.LARGE_FLAT: pd.Interval(350, 640),
+    InsulationSegment.SMALL_MID_TERRACE_HOUSE: pd.Interval(350, 640),
+    InsulationSegment.LARGE_MID_TERRACE_HOUSE: pd.Interval(450, 670),
+    InsulationSegment.SMALL_SEMI_END_TERRACE_HOUSE: pd.Interval(480, 660),
+    InsulationSegment.LARGE_SEMI_END_TERRACE_HOUSE: pd.Interval(600, 690),
+    InsulationSegment.SMALL_DETACHED_HOUSE: pd.Interval(550, 800),
+    InsulationSegment.LARGE_DETACHED_HOUSE: pd.Interval(750, 1_200),
+    InsulationSegment.BUNGALOW: pd.Interval(500, 650),
+}
+
+INTERNAL_WALL_INSULATION_COST = {
+    InsulationSegment.SMALL_FLAT: pd.Interval(2_500, 3_000),
+    InsulationSegment.LARGE_FLAT: pd.Interval(3_000, 4_000),
+    InsulationSegment.SMALL_MID_TERRACE_HOUSE: pd.Interval(3_000, 5_000),
+    InsulationSegment.LARGE_MID_TERRACE_HOUSE: pd.Interval(4_000, 4_000),
+    InsulationSegment.SMALL_SEMI_END_TERRACE_HOUSE: pd.Interval(5_000, 10_400),
+    InsulationSegment.LARGE_SEMI_END_TERRACE_HOUSE: pd.Interval(6_000, 8_000),
+    InsulationSegment.SMALL_DETACHED_HOUSE: pd.Interval(6_600, 8_000),
+    InsulationSegment.LARGE_DETACHED_HOUSE: pd.Interval(7_000, 11_600),
+    InsulationSegment.BUNGALOW: pd.Interval(5_600, 7_000),
+}
+
+LOFT_INSULATION_JOISTS_COST = {
+    InsulationSegment.SMALL_FLAT: pd.Interval(180, 580),
+    InsulationSegment.LARGE_FLAT: pd.Interval(235, 590),
+    InsulationSegment.SMALL_MID_TERRACE_HOUSE: pd.Interval(180, 600),
+    InsulationSegment.LARGE_MID_TERRACE_HOUSE: pd.Interval(200, 645),
+    InsulationSegment.SMALL_SEMI_END_TERRACE_HOUSE: pd.Interval(180, 610),
+    InsulationSegment.LARGE_SEMI_END_TERRACE_HOUSE: pd.Interval(210, 650),
+    InsulationSegment.SMALL_DETACHED_HOUSE: pd.Interval(220, 750),
+    InsulationSegment.LARGE_DETACHED_HOUSE: pd.Interval(300, 955),
+    InsulationSegment.BUNGALOW: pd.Interval(430, 900),
+}
+
+DOUBLE_GLAZING_UPVC_COST = {
+    InsulationSegment.SMALL_FLAT: pd.Interval(1_200, 3_000),
+    InsulationSegment.LARGE_FLAT: pd.Interval(3_000, 4_200),
+    InsulationSegment.SMALL_MID_TERRACE_HOUSE: pd.Interval(3_200, 5_000),
+    InsulationSegment.LARGE_MID_TERRACE_HOUSE: pd.Interval(4_800, 5_500),
+    InsulationSegment.SMALL_SEMI_END_TERRACE_HOUSE: pd.Interval(4_800, 7_000),
+    InsulationSegment.LARGE_SEMI_END_TERRACE_HOUSE: pd.Interval(6_000, 8_000),
+    InsulationSegment.SMALL_DETACHED_HOUSE: pd.Interval(5_000, 7_000),
+    InsulationSegment.LARGE_DETACHED_HOUSE: pd.Interval(7_000, 10_000),
+    InsulationSegment.BUNGALOW: pd.Interval(5_800, 8_000),
+}

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -134,3 +134,19 @@ class TestHousehold:
         assert household.get_upgradable_insulation_elements() == set(
             [Element.GLAZING, Element.WALLS]
         )
+
+    def test_household_gets_non_zero_insulation_quotes_for_upgradable_elements(
+        self,
+    ) -> None:
+
+        household = household_factory(
+            roof_energy_efficiency=random.randint(1, 5),
+            windows_energy_efficiency=random.randint(1, 5),
+            walls_energy_efficiency=random.randint(1, 5),
+        )
+
+        upgradable_elements = household.get_upgradable_insulation_elements()
+        insulation_quotes = household.get_quote_insulation_elements(upgradable_elements)
+
+        assert set(insulation_quotes.keys()) == upgradable_elements
+        assert all(quote > 0 for quote in insulation_quotes.values())

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -121,12 +121,14 @@ class TestHousehold:
         household = household_factory(roof_energy_efficiency=np.NaN)
         assert Element.ROOF not in household.get_upgradable_insulation_elements()
 
-    def test_household_upgradable_elements_reflect_energy_efficiency_scores(
+    def test_household_elements_under_max_energy_efficiency_score_are_upgradable(
         self,
     ) -> None:
 
+        MAX_ENERGY_EFFICIENCY_SCORE = 5
+
         household = household_factory(
-            roof_energy_efficiency=5,
+            roof_energy_efficiency=MAX_ENERGY_EFFICIENCY_SCORE,
             windows_energy_efficiency=3,
             walls_energy_efficiency=2,
         )
@@ -135,7 +137,7 @@ class TestHousehold:
             [Element.GLAZING, Element.WALLS]
         )
 
-    def test_household_gets_non_zero_insulation_quotes_for_upgradable_elements(
+    def test_household_gets_non_zero_insulation_quotes_for_all_upgradable_elements(
         self,
     ) -> None:
 

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -1,11 +1,14 @@
 import datetime
 import random
 
+import numpy as np
+
 from simulation.agents import Household
 from simulation.constants import (
     HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
+    Element,
     Epc,
     HeatingFuel,
     HeatingSystem,
@@ -110,3 +113,24 @@ class TestHousehold:
         assert not household.is_renovating
         household.evaluate_renovation(model)
         assert household.is_renovating
+
+    def test_household_flat_without_roof_cannot_upgrade_roof_insulation(
+        self,
+    ) -> None:
+
+        household = household_factory(roof_energy_efficiency=np.NaN)
+        assert Element.ROOF not in household.get_upgradable_insulation_elements()
+
+    def test_household_upgradable_elements_reflect_energy_efficiency_scores(
+        self,
+    ) -> None:
+
+        household = household_factory(
+            roof_energy_efficiency=5,
+            windows_energy_efficiency=3,
+            walls_energy_efficiency=2,
+        )
+
+        assert household.get_upgradable_insulation_elements() == set(
+            [Element.GLAZING, Element.WALLS]
+        )

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -125,10 +125,8 @@ class TestHousehold:
         self,
     ) -> None:
 
-        MAX_ENERGY_EFFICIENCY_SCORE = 5
-
         household = household_factory(
-            roof_energy_efficiency=MAX_ENERGY_EFFICIENCY_SCORE,
+            roof_energy_efficiency=5,
             windows_energy_efficiency=3,
             walls_energy_efficiency=2,
         )


### PR DESCRIPTION
- Adds method to identify "upgradable" insulation elements. An insulation element refers to the household's roof, windows, or walls. It's upgradable if the energy efficiency is less than 5 (the maximum score from the EPC certificate).
- Adds method to get a cost estimate per element. This is segmented as per the source BEIS report, as different property segments can materially influence costs (e.g. the cost to add wall insulation to a mid-terrace house is very different to a detached house).