### PR TITLE
Add household functionality to choose and install insulation

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -226,7 +226,7 @@ class Household(Agent):
 
         return insulation_quotes
 
-    def choose_n_elements_to_insulate(self):
+    def choose_n_elements_to_insulate(self) -> int:
 
         # Derived from the VERD Project, 2012-2013. UK Data Service. SN: 7773, http://doi.org/10.5255/UKDA-SN-7773-1
         # Based upon the choices of houses in 'Stage 3' - finalising or actively renovating
@@ -234,13 +234,15 @@ class Household(Agent):
         return random.choices([1, 2, 3], weights=[0.76, 0.17, 0.07])[0]
 
     def choose_insulation_elements(
-        self, insulation_quotes: Dict[Element, float], n_elements: int
+        self, insulation_quotes: Dict[Element, float], num_elements: int
     ) -> Dict[Element, float]:
 
-        sorted_tuples = sorted(insulation_quotes.items(), key=lambda item: item[1])
-        quotes_sorted = {k: v for k, v in sorted_tuples}
-
-        return {k: quotes_sorted[k] for k in list(quotes_sorted.keys())[:n_elements]}
+        return {
+            element: insulation_quotes[element]
+            for element in sorted(insulation_quotes, key=insulation_quotes.get)[
+                :num_elements
+            ]
+        }
 
     def install_insulation_elements(
         self, insulation_elements: Dict[Element, float]

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -226,6 +226,13 @@ class Household(Agent):
 
         return insulation_quotes
 
+    def choose_n_elements_to_insulate(self):
+
+        # Derived from the VERD Project, 2012-2013. UK Data Service. SN: 7773, http://doi.org/10.5255/UKDA-SN-7773-1
+        # Based upon the choices of houses in 'Stage 3' - finalising or actively renovating
+
+        return random.choices([1, 2, 3], weights=[0.76, 0.17, 0.07])[0]
+
     def choose_insulation_elements(
         self, insulation_quotes: Dict[Element, float], n_elements: int
     ) -> Dict[Element, float]:
@@ -260,5 +267,7 @@ class Household(Agent):
                 insulation_quotes = self.get_quote_insulation_elements(
                     upgradable_elements
                 )
-                chosen_elements = self.choose_insulation_elements(insulation_quotes, 2)
+                chosen_elements = self.choose_insulation_elements(
+                    insulation_quotes, self.choose_n_elements_to_insulate()
+                )
                 self.install_insulation_elements(chosen_elements)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -235,6 +235,22 @@ class Household(Agent):
 
         return {k: quotes_sorted[k] for k in list(quotes_sorted.keys())[:n_elements]}
 
+    def install_insulation_elements(
+        self, insulation_elements: Dict[Element, float]
+    ) -> None:
+
+        for element in insulation_elements:
+            if element == Element.ROOF:
+                self.roof_energy_efficiency = 5
+            if element == Element.WALLS:
+                self.walls_energy_efficiency = 5
+            if element == Element.GLAZING:
+                self.windows_energy_efficiency = 5
+
+        n_measures = len(insulation_elements)
+        improved_epc_level = max(0, self.epc.value - n_measures)
+        self.epc = Epc(improved_epc_level)
+
     def step(self, model):
         self.evaluate_renovation(model)
         if self.is_renovating:
@@ -244,4 +260,5 @@ class Household(Agent):
                 insulation_quotes = self.get_quote_insulation_elements(
                     upgradable_elements
                 )
-                self.choose_insulation_elements(insulation_quotes, 2)
+                chosen_elements = self.choose_insulation_elements(insulation_quotes, 2)
+                self.install_insulation_elements(chosen_elements)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -226,10 +226,22 @@ class Household(Agent):
 
         return insulation_quotes
 
+    def choose_insulation_elements(
+        self, insulation_quotes: Dict[Element, float], n_elements: int
+    ) -> Dict[Element, float]:
+
+        sorted_tuples = sorted(insulation_quotes.items(), key=lambda item: item[1])
+        quotes_sorted = {k: v for k, v in sorted_tuples}
+
+        return {k: quotes_sorted[k] for k in list(quotes_sorted.keys())[:n_elements]}
+
     def step(self, model):
         self.evaluate_renovation(model)
         if self.is_renovating:
             self.decide_renovation_scope()
             if self.renovate_insulation:
                 upgradable_elements = self.get_upgradable_insulation_elements()
-                self.get_quote_insulation_elements(upgradable_elements)
+                insulation_quotes = self.get_quote_insulation_elements(
+                    upgradable_elements
+                )
+                self.choose_insulation_elements(insulation_quotes, 2)

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -169,3 +169,12 @@ class TestHousehold:
 
         assert chosen_measures.keys() == {Element.ROOF}
 
+    def test_installation_of_insulation_measures_improves_element_energy_efficiency_and_epc(
+        self,
+    ) -> None:
+
+        household = household_factory(roof_energy_efficiency=3, epc=Epc.D)
+        household.install_insulation_elements({Element.ROOF: 1_000})
+
+        assert household.roof_energy_efficiency == 5
+        assert household.epc == Epc.C

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -151,6 +151,13 @@ class TestHousehold:
         assert set(insulation_quotes.keys()) == upgradable_elements
         assert all(quote > 0 for quote in insulation_quotes.values())
 
+    def test_household_chooses_one_to_three_insulation_measures_to_install(
+        self,
+    ) -> None:
+
+        household = household_factory()
+        assert 0 < household.choose_n_elements_to_insulate() <= 3
+
     def test_household_chooses_cheapest_insulation_measures(
         self,
     ) -> None:

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -180,8 +180,30 @@ class TestHousehold:
         self,
     ) -> None:
 
-        household = household_factory(roof_energy_efficiency=3, epc=Epc.D)
+        household = household_factory(
+            roof_energy_efficiency=3, walls_energy_efficiency=2, epc=Epc.D
+        )
         household.install_insulation_elements({Element.ROOF: 1_000})
 
         assert household.roof_energy_efficiency == 5
         assert household.epc == Epc.C
+
+        household.install_insulation_elements({Element.WALLS: 3_000})
+
+        assert household.walls_energy_efficiency == 5
+        assert household.epc == Epc.B
+
+    def test_impact_of_installing_insulation_measures_is_capped_at_epc_A(
+        self,
+    ) -> None:
+
+        epc_A_household = household_factory(
+            roof_energy_efficiency=4,
+            walls_energy_efficiency=5,
+            windows_energy_efficiency=5,
+            epc=Epc.A,
+        )
+        epc_A_household.install_insulation_elements({Element.ROOF: 1_000})
+
+        assert epc_A_household.roof_energy_efficiency == 5
+        assert epc_A_household.epc == Epc.A

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -150,3 +150,22 @@ class TestHousehold:
 
         assert set(insulation_quotes.keys()) == upgradable_elements
         assert all(quote > 0 for quote in insulation_quotes.values())
+
+    def test_household_chooses_cheapest_insulation_measures(
+        self,
+    ) -> None:
+
+        household = household_factory()
+        insulation_quotes = {
+            Element.WALLS: 5_000,
+            Element.GLAZING: 4_000,
+            Element.ROOF: 1_000,
+        }
+        chosen_measures = household.choose_insulation_elements(insulation_quotes, 2)
+
+        assert chosen_measures.keys() == set([Element.ROOF, Element.GLAZING])
+
+        chosen_measures = household.choose_insulation_elements(insulation_quotes, 1)
+
+        assert chosen_measures.keys() == {Element.ROOF}
+


### PR DESCRIPTION
- Adds household method to choose insulation elements, by price ASC
- Adds household method to decide how many insulation elements to install, based upon relative frequency of households installing 1,2 or 3 insulation measures during renovation from the VERD Project, 2012-2013 (UK Data Service. SN: 7773, http://doi.org/10.5255/UKDA-SN-7773-1)
- Adds household method to install these N measures: update the respective energy efficiency of the element, and update overall EPC +1 grade per measure
