### PR TITLE
Add functionality for households to get their heating system options

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -47,6 +47,7 @@ class Household(Agent):
         built_form: BuiltForm,
         heating_system: HeatingSystem,
         epc: Epc,
+        potential_epc: Epc,
         occupant_type: OccupantType,
         is_solid_wall: bool,
         walls_energy_efficiency: int,
@@ -72,6 +73,7 @@ class Household(Agent):
         self.heating_system = heating_system
         self.heating_system_age = random.randint(0, HEATING_SYSTEM_LIFETIME_YEARS)
         self.epc = epc
+        self.potential_epc = potential_epc
         self.walls_energy_efficiency = walls_energy_efficiency
         self.roof_energy_efficiency = roof_energy_efficiency
         self.windows_energy_efficiency = windows_energy_efficiency

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -1,11 +1,15 @@
 import datetime
 import math
 import random
-from typing import Dict, Set
+from typing import TYPE_CHECKING, Dict, Set
 
 import pandas as pd
 
 from abm import Agent
+
+if TYPE_CHECKING:
+    from simulation.model import CnzAgentBasedModel
+
 from simulation.constants import (
     GB_PROPERTY_VALUE_WEIBULL_ALPHA,
     GB_PROPERTY_VALUE_WEIBULL_BETA,
@@ -273,6 +277,26 @@ class Household(Agent):
         n_measures = len(insulation_elements)
         improved_epc_level = max(0, self.epc.value - n_measures)
         self.epc = Epc(improved_epc_level)
+
+    def get_heating_system_options(
+        self, model: "CnzAgentBasedModel"
+    ) -> Set[HeatingSystem]:
+
+        heating_system_options = model.heating_systems
+        if not self.is_heat_pump_suitable or not self.is_heat_pump_aware:
+            heating_system_options -= set(
+                [
+                    HeatingSystem.HEAT_PUMP_AIR_SOURCE,
+                    HeatingSystem.HEAT_PUMP_GROUND_SOURCE,
+                ]
+            )
+
+        if self.off_gas_grid:
+            heating_system_options -= {HeatingSystem.BOILER_GAS}
+        else:
+            heating_system_options -= {HeatingSystem.BOILER_OIL}
+
+        return heating_system_options
 
     def step(self, model):
         self.evaluate_renovation(model)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -174,16 +174,18 @@ class Household(Agent):
             return InsulationSegment.BUNGALOW
 
     @property
-    def is_heat_pump_suitable(self) -> float:
+    def is_heat_pump_suitable(self) -> bool:
 
-        if not all(
-            [
-                self.is_heat_pump_suitable_archetype,
-                self.potential_epc.value <= Epc.C.value,
-            ]
-        ):
-            return False
-        return True
+        return (
+            False
+            if not all(
+                [
+                    self.is_heat_pump_suitable_archetype,
+                    self.potential_epc.value <= Epc.C.value,
+                ]
+            )
+            else True
+        )
 
     def evaluate_renovation(self, model) -> None:
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -169,6 +169,18 @@ class Household(Agent):
         if self.property_type == PropertyType.BUNGALOW:
             return InsulationSegment.BUNGALOW
 
+    @property
+    def is_heat_pump_suitable(self) -> float:
+
+        if not all(
+            [
+                self.is_heat_pump_suitable_archetype,
+                self.potential_epc.value <= Epc.C.value,
+            ]
+        ):
+            return False
+        return True
+
     def evaluate_renovation(self, model) -> None:
 
         step_interval_years = model.step_interval / datetime.timedelta(days=365)

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -55,6 +55,7 @@ def create_households(
             built_form=BuiltForm[household.built_form.upper()],
             heating_system=HeatingSystem[household.heating_system.upper()],
             epc=Epc[household.epc.upper()],
+            potential_epc=Epc[household.potential_epc.upper()],
             occupant_type=OccupantType[household.occupant_type.upper()],
             is_solid_wall=household.is_solid_wall,
             walls_energy_efficiency=household.walls_energy_efficiency,

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -28,6 +28,7 @@ class CnzAgentBasedModel(AgentBasedModel):
         self.step_interval = step_interval
         self.current_datetime = start_datetime
         self.annual_renovation_rate = annual_renovation_rate
+        self.heating_systems = set(HeatingSystem)
 
         super().__init__(UnorderedSpace())
 

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -29,6 +29,7 @@ def household_factory(**agent_attributes):
         "built_form": BuiltForm.MID_TERRACE,
         "heating_system": HeatingSystem.BOILER_GAS,
         "epc": Epc.D,
+        "potential_epc": Epc.C,
         "occupant_type": OccupantType.OWNER_OCCUPIER,
         "is_solid_wall": False,
         "walls_energy_efficiency": 3,
@@ -52,6 +53,7 @@ class TestHousehold:
             built_form=BuiltForm.MID_TERRACE,
             heating_system=HeatingSystem.BOILER_ELECTRIC,
             epc=Epc.C,
+            potential_epc=Epc.B,
             occupant_type=OccupantType.RENTER_PRIVATE,
             is_solid_wall=False,
             walls_energy_efficiency=4,
@@ -70,6 +72,7 @@ class TestHousehold:
         assert household.heating_system == HeatingSystem.BOILER_ELECTRIC
         assert 0 <= household.heating_system_age <= HEATING_SYSTEM_LIFETIME_YEARS
         assert household.epc == Epc.C
+        assert household.potential_epc == Epc.B
         assert household.occupant_type == OccupantType.RENTER_PRIVATE
         assert not household.is_solid_wall
         assert household.walls_energy_efficiency == 4

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -41,6 +41,18 @@ def household_factory(**agent_attributes):
     return Household(**{**default_values, **agent_attributes})
 
 
+def model_factory(**model_attributes):
+    default_values = {
+        "start_datetime": datetime.datetime.now(),
+        "step_interval": datetime.timedelta(minutes=1440),
+        "annual_renovation_rate": 0.05,
+    }
+    return CnzAgentBasedModel(**{**default_values, **model_attributes})
+
+
+HEAT_PUMPS = {HeatingSystem.HEAT_PUMP_AIR_SOURCE, HeatingSystem.HEAT_PUMP_GROUND_SOURCE}
+
+
 class TestHousehold:
     def test_create_household(self) -> None:
         household = household_factory(

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -210,3 +210,61 @@ class TestHousehold:
 
         assert epc_A_household.roof_energy_efficiency == 5
         assert epc_A_household.epc == Epc.A
+
+    def test_households_with_potential_epc_below_C_are_not_heat_pump_suitable(
+        self,
+    ) -> None:
+
+        low_potential_epc_household = household_factory(potential_epc=Epc.D)
+
+        assert not low_potential_epc_household.is_heat_pump_suitable
+
+    def test_households_not_suitable_archetype_are_not_heat_pump_suitable(
+        self,
+    ) -> None:
+
+        unsuitable_archetype_household = household_factory(
+            is_heat_pump_suitable_archetype=False
+        )
+
+        assert not unsuitable_archetype_household.is_heat_pump_suitable
+
+    def test_heat_pumps_not_in_heating_system_options_if_household_not_heat_pump_suitable(
+        self,
+    ) -> None:
+
+        unsuitable_household = household_factory(potential_epc=Epc.D)
+        model = model_factory()
+        assert not HEAT_PUMPS.intersection(
+            unsuitable_household.get_heating_system_options(model)
+        )
+
+    def test_heat_pumps_not_in_heating_system_options_if_household_not_heat_pump_aware(
+        self,
+    ) -> None:
+
+        unaware_household = household_factory(is_heat_pump_aware=False)
+        model = model_factory()
+        assert not HEAT_PUMPS.intersection(
+            unaware_household.get_heating_system_options(model)
+        )
+
+    def test_gas_boiler_not_in_heating_system_options_if_household_off_gas_grid(
+        self,
+    ) -> None:
+
+        off_gas_grid_household = household_factory(off_gas_grid=True)
+        model = model_factory()
+        assert not {HeatingSystem.BOILER_GAS}.intersection(
+            off_gas_grid_household.get_heating_system_options(model)
+        )
+
+    def test_oil_boiler_not_in_heating_system_options_if_household_off_gas_grid(
+        self,
+    ) -> None:
+
+        on_gas_grid_household = household_factory(off_gas_grid=False)
+        model = model_factory()
+        assert not {HeatingSystem.BOILER_OIL}.intersection(
+            on_gas_grid_household.get_heating_system_options(model)
+        )

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -48,6 +48,7 @@ def test_create_households_yields_correctly_initialised_household() -> None:
             "built_form": ["mid_terrace"],
             "heating_system": ["boiler_gas"],
             "epc": ["C"],
+            "potential_epc": ["B"],
             "occupant_type": ["owner_occupier"],
             "is_solid_wall": [False],
             "walls_energy_efficiency": [3],
@@ -72,6 +73,7 @@ def test_create_households_yields_correctly_initialised_household() -> None:
     assert household.built_form == BuiltForm.MID_TERRACE
     assert household.heating_system == HeatingSystem.BOILER_GAS
     assert household.epc == Epc.C
+    assert household.potential_epc == Epc.B
     assert household.occupant_type == OccupantType.OWNER_OCCUPIER
     assert not household.is_solid_wall
     assert household.walls_energy_efficiency == 3
@@ -96,6 +98,7 @@ def test_create_many_households() -> None:
             "built_form": ["mid_terrace"],
             "heating_system": ["boiler_gas"],
             "epc": ["C"],
+            "potential_epc": ["B"],
             "occupant_type": ["owner_occupier"],
             "is_solid_wall": [False],
             "walls_energy_efficiency": [3],


### PR DESCRIPTION
- Adds a default set of heating systems to `CnzAgentBasedModel`
- Adds household attribute `potential_epc`
- Adds household property `is_heat_pump_suitable` (based on property archetype and potential_epc)
- Adds household method to fetch their heating system options, which subsets the model default heating systems, based on `is_heat_pump_suitable`, `is_heat_pump_aware`, and `off_gas_grid` statuses