### PR TITLE
Households have heating system breakdowns, and restricted system choices at breakdown

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -115,7 +115,7 @@ class Household(Agent):
         return random.random() < p
 
     @staticmethod
-    def weibull_hazard_rate(alpha: float, beta: float, age_years: float):
+    def weibull_hazard_rate(alpha: float, beta: float, age_years: float) -> float:
         # Source: # https://en.wikipedia.org/wiki/Weibull_distribution
 
         """

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -54,7 +54,7 @@ class Household(Agent):
         property_type: PropertyType,
         built_form: BuiltForm,
         heating_system: HeatingSystem,
-        heating_system_install_date: datetime.datetime,
+        heating_system_install_date: datetime.date,
         epc: Epc,
         potential_epc: Epc,
         occupant_type: OccupantType,
@@ -204,8 +204,8 @@ class Household(Agent):
             else True
         )
 
-    def heating_system_age_years(self, current_datetime: datetime.datetime) -> float:
-        return (current_datetime - self.heating_system_install_date).days / 365
+    def heating_system_age_years(self, current_date: datetime.date) -> float:
+        return (current_date - self.heating_system_install_date).days / 365
 
     def evaluate_renovation(self, model) -> None:
 
@@ -327,7 +327,7 @@ class Household(Agent):
         probability_density = self.weibull_hazard_rate(
             HAZARD_RATE_HEATING_SYSTEM_ALPHA,
             HAZARD_RATE_HEATING_SYSTEM_BETA,
-            self.heating_system_age_years(model.current_datetime),
+            self.heating_system_age_years(model.current_datetime.date()),
         )
         proba_failure = probability_density * step_interval_years
         if random.random() < proba_failure:

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -16,7 +16,6 @@ from simulation.constants import (
     GB_RENOVATION_BUDGET_WEIBULL_ALPHA,
     GB_RENOVATION_BUDGET_WEIBULL_BETA,
     HEATING_SYSTEM_FUEL,
-    HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
     Element,
@@ -50,6 +49,7 @@ class Household(Agent):
         property_type: PropertyType,
         built_form: BuiltForm,
         heating_system: HeatingSystem,
+        heating_system_install_date: datetime.datetime,
         epc: Epc,
         potential_epc: Epc,
         occupant_type: OccupantType,
@@ -75,7 +75,7 @@ class Household(Agent):
         self.off_gas_grid = off_gas_grid
         self.heating_functioning = True
         self.heating_system = heating_system
-        self.heating_system_age = random.randint(0, HEATING_SYSTEM_LIFETIME_YEARS)
+        self.heating_system_install_date = heating_system_install_date
         self.epc = epc
         self.potential_epc = potential_epc
         self.walls_energy_efficiency = walls_energy_efficiency

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -54,6 +54,8 @@ HEATING_SYSTEM_FUEL: Dict[HeatingSystem, HeatingFuel] = {
 }
 
 HEATING_SYSTEM_LIFETIME_YEARS = 15
+HAZARD_RATE_HEATING_SYSTEM_ALPHA = 6
+HAZARD_RATE_HEATING_SYSTEM_BETA = 15
 
 
 class ConstructionYearBand(enum.Enum):

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -96,3 +96,8 @@ class InsulationSegment(enum.Enum):
     SMALL_DETACHED_HOUSE = 6
     LARGE_DETACHED_HOUSE = 7
     BUNGALOW = 8
+
+
+class EventTrigger(enum.Enum):
+    BREAKDOWN = 0
+    RENOVATION = 1

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -57,7 +57,7 @@ def create_households(
             property_type=PropertyType[household.property_type.upper()],
             built_form=BuiltForm[household.built_form.upper()],
             heating_system=HeatingSystem[household.heating_system.upper()],
-            heating_system_install_date=simulation_start_datetime
+            heating_system_install_date=simulation_start_datetime.date()
             - datetime.timedelta(
                 days=random.randint(0, 365 * HEATING_SYSTEM_LIFETIME_YEARS)
             ),

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -8,6 +8,7 @@ from abm import AgentBasedModel, UnorderedSpace
 from simulation.agents import Household
 from simulation.collectors import get_agent_collectors, model_collectors
 from simulation.constants import (
+    HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
     Epc,
@@ -40,6 +41,7 @@ def create_households(
     num_households: int,
     household_distribution: pd.DataFrame,
     heat_pump_awareness: float,
+    simulation_start_datetime: datetime.datetime,
 ) -> Iterator[Household]:
 
     households = household_distribution.sample(num_households, replace=True)
@@ -55,6 +57,10 @@ def create_households(
             property_type=PropertyType[household.property_type.upper()],
             built_form=BuiltForm[household.built_form.upper()],
             heating_system=HeatingSystem[household.heating_system.upper()],
+            heating_system_install_date=simulation_start_datetime
+            - datetime.timedelta(
+                days=random.randint(0, 365 * HEATING_SYSTEM_LIFETIME_YEARS)
+            ),
             epc=Epc[household.epc.upper()],
             potential_epc=Epc[household.potential_epc.upper()],
             occupant_type=OccupantType[household.occupant_type.upper()],
@@ -83,7 +89,10 @@ def create_and_run_simulation(
     )
 
     households = create_households(
-        num_households, household_distribution, heat_pump_awareness
+        num_households,
+        household_distribution,
+        heat_pump_awareness,
+        model.start_datetime,
     )
     model.add_agents(households)
 

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -301,7 +301,7 @@ class TestHousehold:
             )
         )
 
-    def test_heat_pump_not_in_heating_system_options_if_replacement_triggered_by_breakdown(
+    def test_heat_pump_not_in_heating_system_options_at_breakdown_event(
         self,
     ) -> None:
 
@@ -320,7 +320,7 @@ class TestHousehold:
         )
 
     @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
-    def test_heat_pump_in_heating_system_options_if_replacement_triggered_by_breakdown_but_household_has_heat_pump(
+    def test_heat_pump_in_heating_system_options_at_breakdown_event_if_household_has_heat_pump(
         self,
         heat_pump,
     ) -> None:

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -268,11 +268,10 @@ class TestHousehold:
 
         unaware_household = household_factory(is_heat_pump_aware=False)
         model = model_factory()
-        assert not HEAT_PUMPS.intersection(
-            unaware_household.get_heating_system_options(
-                model, event_trigger=event_trigger
-            )
+        heating_system_options = unaware_household.get_heating_system_options(
+            model, event_trigger
         )
+        assert heating_system_options.intersection(HEAT_PUMPS) == set()
 
     @pytest.mark.parametrize("event_trigger", list(EventTrigger))
     def test_gas_boiler_not_in_heating_system_options_if_household_off_gas_grid(
@@ -281,11 +280,10 @@ class TestHousehold:
 
         off_gas_grid_household = household_factory(off_gas_grid=True)
         model = model_factory()
-        assert not {HeatingSystem.BOILER_GAS}.intersection(
-            off_gas_grid_household.get_heating_system_options(
-                model, event_trigger=event_trigger
-            )
+        heating_system_options = off_gas_grid_household.get_heating_system_options(
+            model, event_trigger
         )
+        assert heating_system_options.intersection({HeatingSystem.BOILER_GAS}) == set()
 
     @pytest.mark.parametrize("event_trigger", list(EventTrigger))
     def test_oil_boiler_not_in_heating_system_options_if_household_off_gas_grid(
@@ -295,11 +293,10 @@ class TestHousehold:
 
         on_gas_grid_household = household_factory(off_gas_grid=False)
         model = model_factory()
-        assert not {HeatingSystem.BOILER_OIL}.intersection(
-            on_gas_grid_household.get_heating_system_options(
-                model, event_trigger=event_trigger
-            )
+        heating_system_options = on_gas_grid_household.get_heating_system_options(
+            model, event_trigger
         )
+        assert heating_system_options.intersection({HeatingSystem.BOILER_OIL}) == set()
 
     def test_heat_pump_not_in_heating_system_options_at_breakdown_event(
         self,
@@ -311,16 +308,15 @@ class TestHousehold:
             heating_system=HeatingSystem.BOILER_GAS,
         )
         model = model_factory()
-        assert heat_pump_suitable_household.is_heat_pump_suitable
-
-        assert not HEAT_PUMPS.intersection(
+        heating_system_options = (
             heat_pump_suitable_household.get_heating_system_options(
-                model, event_trigger=EventTrigger.BREAKDOWN
+                model, EventTrigger.BREAKDOWN
             )
         )
+        assert heating_system_options.intersection(HEAT_PUMPS) == set()
 
     @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
-    def test_heat_pump_in_heating_system_options_at_breakdown_event_if_household_has_heat_pump(
+    def test_current_heat_pump_type_in_heating_system_options_at_breakdown_event_if_household_has_heat_pump(
         self,
         heat_pump,
     ) -> None:
@@ -330,12 +326,10 @@ class TestHousehold:
         )
         model = model_factory()
         assert household_with_heat_pump.is_heat_pump_suitable
-
-        assert {heat_pump}.intersection(
-            household_with_heat_pump.get_heating_system_options(
-                model, event_trigger=EventTrigger.BREAKDOWN
-            )
+        heating_system_options = household_with_heat_pump.get_heating_system_options(
+            model, EventTrigger.BREAKDOWN
         )
+        assert heating_system_options.intersection(HEAT_PUMPS) == {heat_pump}
 
     def test_household_with_ancient_heating_system_experiences_failure(self) -> None:
 

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from simulation.agents import Household
 from simulation.constants import (
-    HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
     Element,
@@ -28,6 +27,7 @@ def household_factory(**agent_attributes):
         "property_type": PropertyType.HOUSE,
         "built_form": BuiltForm.MID_TERRACE,
         "heating_system": HeatingSystem.BOILER_GAS,
+        "heating_system_install_date": datetime.datetime(2021, 1, 1, 0, 0, 0),
         "epc": Epc.D,
         "potential_epc": Epc.C,
         "occupant_type": OccupantType.OWNER_OCCUPIER,
@@ -64,6 +64,7 @@ class TestHousehold:
             property_type=PropertyType.HOUSE,
             built_form=BuiltForm.MID_TERRACE,
             heating_system=HeatingSystem.BOILER_ELECTRIC,
+            heating_system_install_date=datetime.datetime(1995, 1, 1, 0, 0, 0),
             epc=Epc.C,
             potential_epc=Epc.B,
             occupant_type=OccupantType.RENTER_PRIVATE,
@@ -82,7 +83,9 @@ class TestHousehold:
         assert household.property_type == PropertyType.HOUSE
         assert household.built_form == BuiltForm.MID_TERRACE
         assert household.heating_system == HeatingSystem.BOILER_ELECTRIC
-        assert 0 <= household.heating_system_age <= HEATING_SYSTEM_LIFETIME_YEARS
+        assert household.heating_system_install_date == datetime.datetime(
+            1995, 1, 1, 0, 0, 0
+        )
         assert household.epc == Epc.C
         assert household.potential_epc == Epc.B
         assert household.occupant_type == OccupantType.RENTER_PRIVATE

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -340,7 +340,7 @@ class TestHousehold:
     def test_household_with_ancient_heating_system_experiences_failure(self) -> None:
 
         household = household_factory(
-            heating_system_install_date=datetime.datetime(1960, 1, 1, 0, 0, 0)
+            heating_system_install_date=datetime.date(1960, 1, 1)
         )
         model = model_factory(start_datetime=datetime.datetime.now())
 

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -6,7 +6,6 @@ import pytest
 
 from simulation.agents import Household
 from simulation.constants import (
-    HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
     Element,
@@ -30,7 +29,7 @@ def household_factory(**agent_attributes):
         "property_type": PropertyType.HOUSE,
         "built_form": BuiltForm.MID_TERRACE,
         "heating_system": HeatingSystem.BOILER_GAS,
-        "heating_system_install_date": datetime.datetime(2021, 1, 1, 0, 0, 0),
+        "heating_system_install_date": datetime.date(2021, 1, 1),
         "epc": Epc.D,
         "potential_epc": Epc.C,
         "occupant_type": OccupantType.OWNER_OCCUPIER,
@@ -67,7 +66,7 @@ class TestHousehold:
             property_type=PropertyType.HOUSE,
             built_form=BuiltForm.MID_TERRACE,
             heating_system=HeatingSystem.BOILER_ELECTRIC,
-            heating_system_install_date=datetime.datetime(1995, 1, 1, 0, 0, 0),
+            heating_system_install_date=datetime.date(1995, 1, 1),
             epc=Epc.C,
             potential_epc=Epc.B,
             occupant_type=OccupantType.RENTER_PRIVATE,
@@ -86,9 +85,7 @@ class TestHousehold:
         assert household.property_type == PropertyType.HOUSE
         assert household.built_form == BuiltForm.MID_TERRACE
         assert household.heating_system == HeatingSystem.BOILER_ELECTRIC
-        assert household.heating_system_install_date == datetime.datetime(
-            1995, 1, 1, 0, 0, 0
-        )
+        assert household.heating_system_install_date == datetime.date(1995, 1, 1)
         assert household.epc == Epc.C
         assert household.potential_epc == Epc.B
         assert household.occupant_type == OccupantType.RENTER_PRIVATE

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -283,3 +283,16 @@ class TestHousehold:
         assert not {HeatingSystem.BOILER_OIL}.intersection(
             on_gas_grid_household.get_heating_system_options(model)
         )
+
+    def test_household_with_ancient_heating_system_experiences_failure(self) -> None:
+
+        household = household_factory(
+            heating_system_install_date=datetime.datetime(1960, 1, 1, 0, 0, 0)
+        )
+        model = model_factory(start_datetime=datetime.datetime.now())
+
+        assert household.heating_functioning
+
+        household.update_heating_status(model)
+
+        assert not household.heating_functioning

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -78,10 +78,10 @@ def test_create_households_yields_correctly_initialised_household() -> None:
     assert household.built_form == BuiltForm.MID_TERRACE
     assert household.heating_system == HeatingSystem.BOILER_GAS
     assert (
-        simulation_start_datetime
+        simulation_start_datetime.date()
         - datetime.timedelta(days=365 * HEATING_SYSTEM_LIFETIME_YEARS)
         <= household.heating_system_install_date
-        <= simulation_start_datetime
+        <= simulation_start_datetime.date()
     )
     assert household.epc == Epc.C
     assert household.potential_epc == Epc.B

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from simulation.constants import (
+    HEATING_SYSTEM_LIFETIME_YEARS,
     BuiltForm,
     ConstructionYearBand,
     Epc,
@@ -59,8 +60,12 @@ def test_create_households_yields_correctly_initialised_household() -> None:
     )
     num_households = 1
     heat_pump_awareness = 0.4
+    simulation_start_datetime = datetime.datetime.now()
     households = create_households(
-        num_households, household_distribution, heat_pump_awareness
+        num_households,
+        household_distribution,
+        heat_pump_awareness,
+        simulation_start_datetime,
     )
     household = next(households)
 
@@ -72,6 +77,12 @@ def test_create_households_yields_correctly_initialised_household() -> None:
     assert household.property_type == PropertyType.HOUSE
     assert household.built_form == BuiltForm.MID_TERRACE
     assert household.heating_system == HeatingSystem.BOILER_GAS
+    assert (
+        simulation_start_datetime
+        - datetime.timedelta(days=365 * HEATING_SYSTEM_LIFETIME_YEARS)
+        <= household.heating_system_install_date
+        <= simulation_start_datetime
+    )
     assert household.epc == Epc.C
     assert household.potential_epc == Epc.B
     assert household.occupant_type == OccupantType.OWNER_OCCUPIER
@@ -109,7 +120,11 @@ def test_create_many_households() -> None:
     )
     num_households = 100
     heat_pump_awareness = 0.4
+    simulation_start_datetime = datetime.datetime.now()
     households = create_households(
-        num_households, household_distribution, heat_pump_awareness
+        num_households,
+        household_distribution,
+        heat_pump_awareness,
+        simulation_start_datetime,
     )
     assert len(list(households)) == num_households


### PR DESCRIPTION
- Initialise households with `heating_system_install_date`, to replace household `heating_system_age`. This avoids us needing to update heating system age at each timestep.
- Add household method to evaluate if heating is functioning, based on age of heating system and Weibull hazard function parameters
- Modify `household.get_heating_system_options` so heat pumps are not options during a breakdown (due to high industry lead times), unless a household already has a heat pump installed. In that event, the specific type of heat pump already installed (air/ground source) remains an option.