### PR TITLE
Households have discount rates linked to wealth percentile

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from simulation.model import CnzAgentBasedModel
 
 from simulation.constants import (
+    DISCOUNT_RATE_WEIBULL_ALPHA,
+    DISCOUNT_RATE_WEIBULL_BETA,
     GB_PROPERTY_VALUE_WEIBULL_ALPHA,
     GB_PROPERTY_VALUE_WEIBULL_BETA,
     GB_RENOVATION_BUDGET_WEIBULL_ALPHA,
@@ -116,6 +118,19 @@ class Household(Agent):
             GB_PROPERTY_VALUE_WEIBULL_ALPHA,
             GB_PROPERTY_VALUE_WEIBULL_BETA,
             self.property_value,
+        )
+
+    @property
+    def discount_rate(self) -> float:
+
+        return max(
+            1
+            - self.get_weibull_value_from_percentile(
+                DISCOUNT_RATE_WEIBULL_ALPHA,
+                DISCOUNT_RATE_WEIBULL_BETA,
+                self.wealth_percentile,
+            ),
+            0,
         )
 
     @property

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -94,3 +94,10 @@ class InsulationSegment(enum.Enum):
     SMALL_DETACHED_HOUSE = 6
     LARGE_DETACHED_HOUSE = 7
     BUNGALOW = 8
+
+
+# parameters chosen to align to a distribution of discount rates obtained from an investigation of 1,217 random
+# U.S. homeowners given choice experiments relating to the purchase of a water heater (mean 19%; std. 23%)
+# Individual Time Preferences and Energy Efficiency (NBER Working Paper No. 20969)
+DISCOUNT_RATE_WEIBULL_ALPHA = 0.8
+DISCOUNT_RATE_WEIBULL_BETA = 0.165

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -280,3 +280,12 @@ class TestHousehold:
         assert not {HeatingSystem.BOILER_OIL}.intersection(
             on_gas_grid_household.get_heating_system_options(model)
         )
+
+    def test_household_with_lower_wealth_has_higher_discount_rate(self) -> None:
+
+        household = household_factory(property_value=random.randint(50_000, 400_000))
+        higher_wealth_household = household_factory(
+            property_value=household.property_value * 1.1
+        )
+
+        assert household.discount_rate > higher_wealth_household.discount_rate


### PR DESCRIPTION
- Add Weibull parameters approximately corresponding to a distribution of discount rates for households selecting heating system related purchases (Individual Time Preferences and Energy Efficiency - NBER Working Paper No. 20969)
- Add household method to fetch a discount rate value from this distribution, based on wealth percentile. There is an inverse relationship between discount rate and wealth.