### PR TITLE
Households fetch costs of heating systems (unit, install, and fuel costs)

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         args.household_distribution,
         args.heat_pump_awareness,
         args.annual_renovation_rate,
-        args.future_cashflow_lookahead_years,
+        args.household_num_lookahead_years,
     )
 
     write_jsonlines(history, args.history_filename)

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -35,6 +35,12 @@ def parse_args(args=None):
     parser.add_argument("--household-distribution", type=pd.read_csv)
     parser.add_argument("--heat-pump-awareness", type=float, default=0.4)
     parser.add_argument("--annual-renovation-rate", type=float, default=0.05)
+    parser.add_argument(
+        "--household-num-lookahead-years",
+        type=int,
+        default=3,
+        help="The number of years households look ahead when making purchasing decisions; any cash flows to be exchanged further than this number of years in the future are valued at £0 by households",
+    )
 
     return parser.parse_args(args)
 
@@ -50,6 +56,7 @@ if __name__ == "__main__":
         args.household_distribution,
         args.heat_pump_awareness,
         args.annual_renovation_rate,
+        args.future_cashflow_lookahead_years,
     )
 
     write_jsonlines(history, args.history_filename)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -42,6 +42,7 @@ from simulation.costs import (
     DOUBLE_GLAZING_UPVC_COST,
     INTERNAL_WALL_INSULATION_COST,
     LOFT_INSULATION_JOISTS_COST,
+    get_heating_fuel_costs_net_present_value,
     get_unit_and_install_costs,
 )
 
@@ -396,6 +397,9 @@ class Household(Agent):
             )
             for heating_system in heating_system_options:
                 get_unit_and_install_costs(self, heating_system)
+                get_heating_fuel_costs_net_present_value(
+                    self, heating_system, model.household_num_lookahead_years
+                )
 
         self.evaluate_renovation(model)
         if self.is_renovating:

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from simulation.model import CnzAgentBasedModel
 
 from simulation.constants import (
+    COEFFICIENT_OF_PERFORMANCE,
     DISCOUNT_RATE_WEIBULL_ALPHA,
     DISCOUNT_RATE_WEIBULL_BETA,
     GB_PROPERTY_VALUE_WEIBULL_ALPHA,
@@ -20,6 +21,7 @@ from simulation.constants import (
     HAZARD_RATE_HEATING_SYSTEM_ALPHA,
     HAZARD_RATE_HEATING_SYSTEM_BETA,
     HEAT_PUMP_CAPACITY_SCALE_FACTOR,
+    HEATING_KWH_PER_SQM_ANNUAL,
     HEATING_SYSTEM_FUEL,
     MAX_HEAT_PUMP_CAPACITY_KW,
     MIN_HEAT_PUMP_CAPACITY_KW,
@@ -237,6 +239,13 @@ class Household(Agent):
             return PropertySize.LARGE
         else:
             return PropertySize.MEDIUM
+
+    @property
+    def annual_kwh_heating_demand(self) -> float:
+
+        return (
+            self.floor_area_sqm * HEATING_KWH_PER_SQM_ANNUAL
+        ) / COEFFICIENT_OF_PERFORMANCE[self.heating_system]
 
     def heating_system_age_years(self, current_date: datetime.date) -> float:
         return (current_date - self.heating_system_install_date).days / 365

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
     from simulation.model import CnzAgentBasedModel
 
 from simulation.constants import (
-    COEFFICIENT_OF_PERFORMANCE,
     DISCOUNT_RATE_WEIBULL_ALPHA,
     DISCOUNT_RATE_WEIBULL_BETA,
+    FUEL_KWH_TO_HEAT_KWH,
     GB_PROPERTY_VALUE_WEIBULL_ALPHA,
     GB_PROPERTY_VALUE_WEIBULL_BETA,
     GB_RENOVATION_BUDGET_WEIBULL_ALPHA,
@@ -246,7 +246,7 @@ class Household(Agent):
 
         return (
             self.floor_area_sqm * HEATING_KWH_PER_SQM_ANNUAL
-        ) / COEFFICIENT_OF_PERFORMANCE[self.heating_system]
+        ) / FUEL_KWH_TO_HEAT_KWH[self.heating_system]
 
     def heating_system_age_years(self, current_date: datetime.date) -> float:
         return (current_date - self.heating_system_install_date).days / 365

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -141,7 +141,7 @@ class PropertySize(enum.Enum):
 # 133 * 0.92 = 122kWh/m2a
 HEATING_KWH_PER_SQM_ANNUAL = 122
 
-COEFFICIENT_OF_PERFORMANCE: Dict[HeatingSystem, float] = {
+FUEL_KWH_TO_HEAT_KWH: Dict[HeatingSystem, float] = {
     # The conversion factor between 1kWh of fuel and useful heat. For example:
     # Gas Boilers ~ 0.9, since 1kWh of gas produces ~0.9kWh of heat (due to inefficiencies in the boiler)
     HeatingSystem.BOILER_GAS: 0.92,
@@ -149,4 +149,12 @@ COEFFICIENT_OF_PERFORMANCE: Dict[HeatingSystem, float] = {
     HeatingSystem.BOILER_ELECTRIC: 0.995,
     HeatingSystem.HEAT_PUMP_AIR_SOURCE: 3,
     HeatingSystem.HEAT_PUMP_GROUND_SOURCE: 4,
+}
+
+HEAT_PUMPS = {HeatingSystem.HEAT_PUMP_AIR_SOURCE, HeatingSystem.HEAT_PUMP_GROUND_SOURCE}
+
+BOILERS = {
+    HeatingSystem.BOILER_GAS,
+    HeatingSystem.BOILER_OIL,
+    HeatingSystem.BOILER_ELECTRIC,
 }

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -134,3 +134,19 @@ class PropertySize(enum.Enum):
     SMALL = 0
     MEDIUM = 1
     LARGE = 2
+
+
+# Source: https://www.ovoenergy.com/guides/energy-guides/how-much-heating-energy-do-you-use
+# Assume figure of 133kWh/m2a a reflects an average heating system Coefficient of Performance of 0.92 (gas boiler)
+# 133 * 0.92 = 122kWh/m2a
+HEATING_KWH_PER_SQM_ANNUAL = 122
+
+COEFFICIENT_OF_PERFORMANCE: Dict[HeatingSystem, float] = {
+    # The conversion factor between 1kWh of fuel and useful heat. For example:
+    # Gas Boilers ~ 0.9, since 1kWh of gas produces ~0.9kWh of heat (due to inefficiencies in the boiler)
+    HeatingSystem.BOILER_GAS: 0.92,
+    HeatingSystem.BOILER_OIL: 0.92,
+    HeatingSystem.BOILER_ELECTRIC: 0.995,
+    HeatingSystem.HEAT_PUMP_AIR_SOURCE: 3,
+    HeatingSystem.HEAT_PUMP_GROUND_SOURCE: 4,
+}

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -128,3 +128,9 @@ MIN_HEAT_PUMP_CAPACITY_KW = {
     HeatingSystem.HEAT_PUMP_AIR_SOURCE: 2.0,
     HeatingSystem.HEAT_PUMP_GROUND_SOURCE: 2.0,
 }
+
+
+class PropertySize(enum.Enum):
+    SMALL = 0
+    MEDIUM = 1
+    LARGE = 2

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -1,5 +1,5 @@
 import random
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
 import pandas as pd
 
@@ -11,6 +11,9 @@ from simulation.constants import (
     InsulationSegment,
     PropertySize,
 )
+
+if TYPE_CHECKING:
+    from simulation.agents import Household
 
 # Source: BEIS - WHAT DOES IT COST TO RETROFIT HOMES?
 
@@ -182,7 +185,7 @@ def discount_annual_cash_flow(
 
 def get_heating_fuel_costs_net_present_value(
     household: "Household",
-    heating_system: "HeatingSystem",
+    heating_system: HeatingSystem,
     num_lookahead_years: int,
 ):
 

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -1,6 +1,9 @@
+import random
+from typing import Dict
+
 import pandas as pd
 
-from simulation.constants import InsulationSegment
+from simulation.constants import HeatingSystem, InsulationSegment, PropertySize
 
 # Source: BEIS - WHAT DOES IT COST TO RETROFIT HOMES?
 
@@ -51,3 +54,106 @@ DOUBLE_GLAZING_UPVC_COST = {
     InsulationSegment.LARGE_DETACHED_HOUSE: pd.Interval(7_000, 10_000),
     InsulationSegment.BUNGALOW: pd.Interval(5_800, 8_000),
 }
+
+MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE: Dict[int, int] = {
+    # Source: RHI December 2020 Data
+    # Adjusted for monotonicity: cost at each capacity >= highest trailing value
+    1: 1500,
+    2: 3000,
+    3: 4500,
+    4: 6000,
+    5: 7500,
+    6: 7500,
+    7: 8050,
+    8: 9200,
+    9: 10350,
+    10: 11500,
+    11: 11500,
+    12: 11500,
+    13: 12350,
+    14: 13300,
+    15: 14250,
+    16: 14250,
+    17: 14250,
+    18: 14580,
+    19: 15390,
+    20: 16200,
+}
+
+MEDIAN_COST_GBP_HEAT_PUMP_GROUND_SOURCE: Dict[int, int] = {
+    # Adjusted for monotonicity: cost at each capacity >= highest trailing value
+    1: 1800,
+    2: 3600,
+    3: 5400,
+    4: 7200,
+    5: 9000,
+    6: 10920,
+    7: 12740,
+    8: 14560,
+    9: 16380,
+    10: 18200,
+    11: 18200,
+    12: 18840,
+    13: 20410,
+    14: 21980,
+    15: 23550,
+    16: 23550,
+    17: 24990,
+    18: 26460,
+    19: 27930,
+    20: 29400,
+    21: 29400,
+    22: 29400,
+    23: 30590,
+    24: 31920,
+    25: 33250,
+}
+
+MEAN_COST_GBP_BOILER_GAS: Dict[PropertySize, int] = {
+    # Source: https://www.boilerguide.co.uk/articles/what-size-boiler-needed
+    PropertySize.SMALL: 2277,
+    PropertySize.MEDIUM: 2347,
+    PropertySize.LARGE: 2476,
+}
+
+MEAN_COST_GBP_BOILER_OIL: Dict[PropertySize, int] = {
+    # Source: https://www.theecoexperts.co.uk/boilers/oil-boiler
+    PropertySize.SMALL: 2350,
+    PropertySize.MEDIUM: 2183,
+    PropertySize.LARGE: 3025,
+}
+
+MEAN_COST_GBP_BOILER_ELECTRIC: Dict[PropertySize, int] = {
+    # Source: https://www.boilerguide.co.uk/articles/best-electric-boilers
+    PropertySize.SMALL: 1250,
+    PropertySize.MEDIUM: 1750,
+    PropertySize.LARGE: 2250,
+}
+
+
+def get_unit_and_install_costs(household, heating_system):
+
+    costs = 0
+
+    if heating_system != household.heating_system:
+        decommissioning_costs = random.randint(500, 2_000)
+        costs += decommissioning_costs
+
+    if heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
+        kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)
+        costs += MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity]
+
+    if heating_system == HeatingSystem.HEAT_PUMP_GROUND_SOURCE:
+        kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)
+        costs += MEDIAN_COST_GBP_HEAT_PUMP_GROUND_SOURCE[kw_capacity]
+
+    if heating_system == HeatingSystem.BOILER_GAS:
+        costs += MEAN_COST_GBP_BOILER_GAS[household.property_size]
+
+    if heating_system == HeatingSystem.BOILER_OIL:
+        costs += MEAN_COST_GBP_BOILER_OIL[household.property_size]
+
+    if heating_system == HeatingSystem.BOILER_ELECTRIC:
+        costs += MEAN_COST_GBP_BOILER_ELECTRIC[household.property_size]
+
+    return costs

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -189,9 +189,11 @@ def get_heating_fuel_costs_net_present_value(
     num_lookahead_years: int,
 ):
 
-    annual_heating_demand_kwh = (
-        household.annual_kwh_heating_demand * COEFFICIENT_OF_PERFORMANCE[heating_system]
+    SCALE_FACTOR_COP = (
+        COEFFICIENT_OF_PERFORMANCE[household.heating_system]
+        / COEFFICIENT_OF_PERFORMANCE[heating_system]
     )
+    annual_heating_demand_kwh = household.annual_kwh_heating_demand * SCALE_FACTOR_COP
     annual_heating_bill = (
         annual_heating_demand_kwh
         * HEATING_FUEL_PRICE_GBP_PER_KWH[HEATING_SYSTEM_FUEL[heating_system]]

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict
 import pandas as pd
 
 from simulation.constants import (
-    COEFFICIENT_OF_PERFORMANCE,
+    FUEL_KWH_TO_HEAT_KWH,
     HEATING_SYSTEM_FUEL,
     HeatingFuel,
     HeatingSystem,
@@ -148,7 +148,9 @@ HEATING_FUEL_PRICE_GBP_PER_KWH: Dict[HeatingFuel, float] = {
 }
 
 
-def get_unit_and_install_costs(household, heating_system):
+def get_unit_and_install_costs(
+    household: "Household", heating_system: HeatingSystem
+) -> int:
 
     costs = 0
 
@@ -190,8 +192,8 @@ def get_heating_fuel_costs_net_present_value(
 ):
 
     SCALE_FACTOR_COP = (
-        COEFFICIENT_OF_PERFORMANCE[household.heating_system]
-        / COEFFICIENT_OF_PERFORMANCE[heating_system]
+        FUEL_KWH_TO_HEAT_KWH[household.heating_system]
+        / FUEL_KWH_TO_HEAT_KWH[heating_system]
     )
     annual_heating_demand_kwh = household.annual_kwh_heating_demand * SCALE_FACTOR_COP
     annual_heating_bill = (

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -24,12 +24,14 @@ class CnzAgentBasedModel(AgentBasedModel):
         start_datetime,
         step_interval,
         annual_renovation_rate,
+        household_num_lookahead_years,
     ):
         self.start_datetime = start_datetime
         self.step_interval = step_interval
         self.current_datetime = start_datetime
         self.annual_renovation_rate = annual_renovation_rate
         self.heating_systems = set(HeatingSystem)
+        self.household_num_lookahead_years = household_num_lookahead_years
 
         super().__init__(UnorderedSpace())
 
@@ -81,11 +83,13 @@ def create_and_run_simulation(
     household_distribution: pd.DataFrame,
     heat_pump_awareness: float,
     annual_renovation_rate: float,
+    household_num_lookahead_years: int,
 ):
     model = CnzAgentBasedModel(
         start_datetime=start_datetime,
         step_interval=step_interval,
         annual_renovation_rate=annual_renovation_rate,
+        household_num_lookahead_years=household_num_lookahead_years,
     )
 
     households = create_households(

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -1,0 +1,46 @@
+import datetime
+
+from simulation.agents import Household
+from simulation.constants import (
+    BuiltForm,
+    ConstructionYearBand,
+    Epc,
+    HeatingSystem,
+    OccupantType,
+    PropertyType,
+)
+from simulation.model import CnzAgentBasedModel
+
+
+def household_factory(**agent_attributes):
+    default_values = {
+        "location": "Test Location",
+        "property_value": 264_000,
+        "floor_area_sqm": 82,
+        "off_gas_grid": False,
+        "construction_year_band": ConstructionYearBand.BUILT_1919_1944,
+        "property_type": PropertyType.HOUSE,
+        "built_form": BuiltForm.MID_TERRACE,
+        "heating_system": HeatingSystem.BOILER_GAS,
+        "heating_system_install_date": datetime.date(2021, 1, 1),
+        "epc": Epc.D,
+        "potential_epc": Epc.C,
+        "occupant_type": OccupantType.OWNER_OCCUPIER,
+        "is_solid_wall": False,
+        "walls_energy_efficiency": 3,
+        "windows_energy_efficiency": 3,
+        "roof_energy_efficiency": 3,
+        "is_heat_pump_suitable_archetype": True,
+        "is_heat_pump_aware": True,
+    }
+    return Household(**{**default_values, **agent_attributes})
+
+
+def model_factory(**model_attributes):
+    default_values = {
+        "start_datetime": datetime.datetime.now(),
+        "step_interval": datetime.timedelta(minutes=1440),
+        "annual_renovation_rate": 0.05,
+        "household_num_lookahead_years": 3,
+    }
+    return CnzAgentBasedModel(**{**default_values, **model_attributes})

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -4,8 +4,8 @@ import random
 import numpy as np
 import pytest
 
-from simulation.agents import Household
 from simulation.constants import (
+    HEAT_PUMPS,
     MAX_HEAT_PUMP_CAPACITY_KW,
     MIN_HEAT_PUMP_CAPACITY_KW,
     BuiltForm,
@@ -18,44 +18,7 @@ from simulation.constants import (
     OccupantType,
     PropertyType,
 )
-from simulation.model import CnzAgentBasedModel
-
-
-def household_factory(**agent_attributes):
-    default_values = {
-        "location": "Test Location",
-        "property_value": 264_000,
-        "floor_area_sqm": 82,
-        "off_gas_grid": False,
-        "construction_year_band": ConstructionYearBand.BUILT_1919_1944,
-        "property_type": PropertyType.HOUSE,
-        "built_form": BuiltForm.MID_TERRACE,
-        "heating_system": HeatingSystem.BOILER_GAS,
-        "heating_system_install_date": datetime.date(2021, 1, 1),
-        "epc": Epc.D,
-        "potential_epc": Epc.C,
-        "occupant_type": OccupantType.OWNER_OCCUPIER,
-        "is_solid_wall": False,
-        "walls_energy_efficiency": 3,
-        "windows_energy_efficiency": 3,
-        "roof_energy_efficiency": 3,
-        "is_heat_pump_suitable_archetype": True,
-        "is_heat_pump_aware": True,
-    }
-    return Household(**{**default_values, **agent_attributes})
-
-
-def model_factory(**model_attributes):
-    default_values = {
-        "start_datetime": datetime.datetime.now(),
-        "step_interval": datetime.timedelta(minutes=1440),
-        "annual_renovation_rate": 0.05,
-        "household_num_lookahead_years": 3,
-    }
-    return CnzAgentBasedModel(**{**default_values, **model_attributes})
-
-
-HEAT_PUMPS = {HeatingSystem.HEAT_PUMP_AIR_SOURCE, HeatingSystem.HEAT_PUMP_GROUND_SOURCE}
+from simulation.tests.common import household_factory, model_factory
 
 
 class TestHousehold:

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -50,6 +50,7 @@ def model_factory(**model_attributes):
         "start_datetime": datetime.datetime.now(),
         "step_interval": datetime.timedelta(minutes=1440),
         "annual_renovation_rate": 0.05,
+        "household_num_lookahead_years": 3,
     }
     return CnzAgentBasedModel(**{**default_values, **model_attributes})
 
@@ -123,7 +124,7 @@ class TestHousehold:
         self,
     ) -> None:
 
-        model = CnzAgentBasedModel(
+        model = model_factory(
             start_datetime=datetime.datetime.now(),
             step_interval=datetime.timedelta(days=365),
             annual_renovation_rate=1.0,

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -379,3 +379,42 @@ class TestHousehold:
             <= household.compute_heat_pump_capacity_kw(heat_pump)
             <= MAX_HEAT_PUMP_CAPACITY_KW[heat_pump]
         )
+
+    @pytest.mark.parametrize("heating_system", set(HeatingSystem))
+    def test_annual_heating_demand_increases_with_floor_area(
+        self,
+        heating_system,
+    ) -> None:
+
+        household = household_factory(
+            floor_area_sqm=random.randint(20, 180), heating_system=heating_system
+        )
+        larger_household = household_factory(
+            floor_area_sqm=household.floor_area_sqm * 1.1,
+            heating_system=heating_system,
+        )
+
+        assert (
+            household.annual_kwh_heating_demand
+            < larger_household.annual_kwh_heating_demand
+        )
+
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_annual_heating_demand_is_lower_for_more_efficient_heating_systems(
+        self,
+        heat_pump,
+    ) -> None:
+
+        household_with_gas_boiler = household_factory(
+            floor_area_sqm=random.randint(20, 180),
+            heating_system=HeatingSystem.BOILER_GAS,
+        )
+        household_with_heat_pump = household_factory(
+            floor_area_sqm=household_with_gas_boiler.floor_area_sqm,
+            heating_system=heat_pump,
+        )
+
+        assert (
+            household_with_heat_pump.annual_kwh_heating_demand
+            < household_with_gas_boiler.annual_kwh_heating_demand
+        )

--- a/simulation/tests/test_collectors.py
+++ b/simulation/tests/test_collectors.py
@@ -1,17 +1,7 @@
 import datetime
 
 from simulation.collectors import is_first_step
-from simulation.model import CnzAgentBasedModel
-
-
-def model_factory(**model_attributes):
-    default_values = {
-        "start_datetime": datetime.datetime.now(),
-        "step_interval": datetime.timedelta(minutes=1440),
-        "annual_renovation_rate": 0.05,
-        "household_num_lookahead_years": 3,
-    }
-    return CnzAgentBasedModel(**{**default_values, **model_attributes})
+from simulation.tests.common import model_factory
 
 
 def test_is_first_step() -> None:

--- a/simulation/tests/test_collectors.py
+++ b/simulation/tests/test_collectors.py
@@ -9,6 +9,7 @@ def model_factory(**model_attributes):
         "start_datetime": datetime.datetime.now(),
         "step_interval": datetime.timedelta(minutes=1440),
         "annual_renovation_rate": 0.05,
+        "household_num_lookahead_years": 3,
     }
     return CnzAgentBasedModel(**{**default_values, **model_attributes})
 

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -5,6 +5,8 @@ import pytest
 
 from simulation.agents import Household
 from simulation.constants import (
+    BOILERS,
+    HEAT_PUMPS,
     BuiltForm,
     ConstructionYearBand,
     Epc,
@@ -52,14 +54,6 @@ def model_factory(**model_attributes):
     return CnzAgentBasedModel(**{**default_values, **model_attributes})
 
 
-HEAT_PUMPS = {HeatingSystem.HEAT_PUMP_AIR_SOURCE, HeatingSystem.HEAT_PUMP_GROUND_SOURCE}
-BOILERS = {
-    HeatingSystem.BOILER_GAS,
-    HeatingSystem.BOILER_OIL,
-    HeatingSystem.BOILER_ELECTRIC,
-}
-
-
 class TestCosts:
     @pytest.mark.parametrize("heating_system", set(HeatingSystem))
     def test_cost_of_any_heating_system_is_cheaper_if_already_installed(
@@ -69,9 +63,7 @@ class TestCosts:
             heating_system=heating_system
         )
 
-        alternative_system = random.choice(
-            [system for system in set(HeatingSystem) if system != heating_system]
-        )
+        alternative_system = random.choice(list(set(HeatingSystem) - {heating_system}))
         household_switching_system = household_factory(
             heating_system=alternative_system
         )

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -1,57 +1,13 @@
-import datetime
 import random
 
 import pytest
 
-from simulation.agents import Household
-from simulation.constants import (
-    BOILERS,
-    HEAT_PUMPS,
-    BuiltForm,
-    ConstructionYearBand,
-    Epc,
-    HeatingSystem,
-    OccupantType,
-    PropertyType,
-)
+from simulation.constants import BOILERS, HEAT_PUMPS, HeatingSystem
 from simulation.costs import (
     get_heating_fuel_costs_net_present_value,
     get_unit_and_install_costs,
 )
-from simulation.model import CnzAgentBasedModel
-
-
-def household_factory(**agent_attributes):
-    default_values = {
-        "location": "Test Location",
-        "property_value": 264_000,
-        "floor_area_sqm": 82,
-        "off_gas_grid": False,
-        "construction_year_band": ConstructionYearBand.BUILT_1919_1944,
-        "property_type": PropertyType.HOUSE,
-        "built_form": BuiltForm.MID_TERRACE,
-        "heating_system": HeatingSystem.BOILER_GAS,
-        "heating_system_install_date": datetime.date(2021, 1, 1),
-        "epc": Epc.D,
-        "potential_epc": Epc.C,
-        "occupant_type": OccupantType.OWNER_OCCUPIER,
-        "is_solid_wall": False,
-        "walls_energy_efficiency": 3,
-        "windows_energy_efficiency": 3,
-        "roof_energy_efficiency": 3,
-        "is_heat_pump_suitable_archetype": True,
-        "is_heat_pump_aware": True,
-    }
-    return Household(**{**default_values, **agent_attributes})
-
-
-def model_factory(**model_attributes):
-    default_values = {
-        "start_datetime": datetime.datetime.now(),
-        "step_interval": datetime.timedelta(minutes=1440),
-        "annual_renovation_rate": 0.05,
-    }
-    return CnzAgentBasedModel(**{**default_values, **model_attributes})
+from simulation.tests.common import household_factory
 
 
 class TestCosts:

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -12,7 +12,10 @@ from simulation.constants import (
     OccupantType,
     PropertyType,
 )
-from simulation.costs import get_unit_and_install_costs
+from simulation.costs import (
+    get_heating_fuel_costs_net_present_value,
+    get_unit_and_install_costs,
+)
 from simulation.model import CnzAgentBasedModel
 
 
@@ -113,3 +116,21 @@ class TestCosts:
         assert get_unit_and_install_costs(
             household, boiler
         ) <= get_unit_and_install_costs(larger_household, boiler)
+
+    @pytest.mark.parametrize("heating_system", set(HeatingSystem))
+    def test_fuel_bills_net_present_value_decreases_as_discount_rate_increases(
+        self,
+        heating_system,
+    ) -> None:
+
+        num_look_ahead_years = random.randint(2, 10)
+        household = household_factory(property_value=random.randint(50_000, 300_000))
+        wealthier_household = household_factory(
+            property_value=household.property_value * 1.1
+        )
+
+        assert get_heating_fuel_costs_net_present_value(
+            household, heating_system, num_look_ahead_years
+        ) < get_heating_fuel_costs_net_present_value(
+            wealthier_household, heating_system, num_look_ahead_years
+        )

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -129,6 +129,8 @@ class TestCosts:
             property_value=household.property_value * 1.1
         )
 
+        assert household.discount_rate > wealthier_household.discount_rate
+
         assert get_heating_fuel_costs_net_present_value(
             household, heating_system, num_look_ahead_years
         ) < get_heating_fuel_costs_net_present_value(

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -1,0 +1,115 @@
+import datetime
+import random
+
+import pytest
+
+from simulation.agents import Household
+from simulation.constants import (
+    BuiltForm,
+    ConstructionYearBand,
+    Epc,
+    HeatingSystem,
+    OccupantType,
+    PropertyType,
+)
+from simulation.costs import get_unit_and_install_costs
+from simulation.model import CnzAgentBasedModel
+
+
+def household_factory(**agent_attributes):
+    default_values = {
+        "location": "Test Location",
+        "property_value": 264_000,
+        "floor_area_sqm": 82,
+        "off_gas_grid": False,
+        "construction_year_band": ConstructionYearBand.BUILT_1919_1944,
+        "property_type": PropertyType.HOUSE,
+        "built_form": BuiltForm.MID_TERRACE,
+        "heating_system": HeatingSystem.BOILER_GAS,
+        "heating_system_install_date": datetime.date(2021, 1, 1),
+        "epc": Epc.D,
+        "potential_epc": Epc.C,
+        "occupant_type": OccupantType.OWNER_OCCUPIER,
+        "is_solid_wall": False,
+        "walls_energy_efficiency": 3,
+        "windows_energy_efficiency": 3,
+        "roof_energy_efficiency": 3,
+        "is_heat_pump_suitable_archetype": True,
+        "is_heat_pump_aware": True,
+    }
+    return Household(**{**default_values, **agent_attributes})
+
+
+def model_factory(**model_attributes):
+    default_values = {
+        "start_datetime": datetime.datetime.now(),
+        "step_interval": datetime.timedelta(minutes=1440),
+        "annual_renovation_rate": 0.05,
+    }
+    return CnzAgentBasedModel(**{**default_values, **model_attributes})
+
+
+HEAT_PUMPS = {HeatingSystem.HEAT_PUMP_AIR_SOURCE, HeatingSystem.HEAT_PUMP_GROUND_SOURCE}
+BOILERS = {
+    HeatingSystem.BOILER_GAS,
+    HeatingSystem.BOILER_OIL,
+    HeatingSystem.BOILER_ELECTRIC,
+}
+
+
+class TestCosts:
+    @pytest.mark.parametrize("heating_system", set(HeatingSystem))
+    def test_cost_of_any_heating_system_is_cheaper_if_already_installed(
+        self, heating_system
+    ) -> None:
+        household_sticking_same_system = household_factory(
+            heating_system=heating_system
+        )
+
+        alternative_system = random.choice(
+            [system for system in set(HeatingSystem) if system != heating_system]
+        )
+        household_switching_system = household_factory(
+            heating_system=alternative_system
+        )
+
+        assert get_unit_and_install_costs(
+            household_sticking_same_system, heating_system
+        ) < get_unit_and_install_costs(household_switching_system, heating_system)
+
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_cost_of_heat_pump_increases_with_kw_capacity_required(
+        self,
+        heat_pump,
+    ) -> None:
+
+        household = household_factory(
+            floor_area_sqm=random.randint(20, 200), heating_system=heat_pump
+        )
+        larger_household = household_factory(
+            floor_area_sqm=household.floor_area_sqm * 1.2,
+            heating_system=heat_pump,
+        )
+
+        assert household.compute_heat_pump_capacity_kw(
+            heat_pump
+        ) <= larger_household.compute_heat_pump_capacity_kw(heat_pump)
+        assert get_unit_and_install_costs(
+            household, heat_pump
+        ) <= get_unit_and_install_costs(larger_household, heat_pump)
+
+    @pytest.mark.parametrize("boiler", BOILERS)
+    def test_cost_of_boiler_increases_with_property_size(
+        self,
+        boiler,
+    ) -> None:
+        household = household_factory(
+            floor_area_sqm=random.randint(20, 200), heating_system=boiler
+        )
+        larger_household = household_factory(
+            floor_area_sqm=household.floor_area_sqm * 1.5, heating_system=boiler
+        )
+
+        assert get_unit_and_install_costs(
+            household, boiler
+        ) <= get_unit_and_install_costs(larger_household, boiler)

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -12,17 +12,8 @@ from simulation.constants import (
     OccupantType,
     PropertyType,
 )
-from simulation.model import CnzAgentBasedModel, create_households
-
-
-def model_factory(**model_attributes):
-    default_values = {
-        "start_datetime": datetime.datetime.now(),
-        "step_interval": datetime.timedelta(minutes=1440),
-        "annual_renovation_rate": 0.05,
-        "household_num_lookahead_years": 3,
-    }
-    return CnzAgentBasedModel(**{**default_values, **model_attributes})
+from simulation.model import create_households
+from simulation.tests.common import model_factory
 
 
 class TestCnzAgentBasedModel:

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -20,6 +20,7 @@ def model_factory(**model_attributes):
         "start_datetime": datetime.datetime.now(),
         "step_interval": datetime.timedelta(minutes=1440),
         "annual_renovation_rate": 0.05,
+        "household_num_lookahead_years": 3,
     }
     return CnzAgentBasedModel(**{**default_values, **model_attributes})
 


### PR DESCRIPTION
- Costs of unit, install and fuel prices are added as constants
- Households fetch unit and install costs (based on required capacity for heat pumps, or coarse property band sizes for boilers). Install costs depend on whether it's a like-for-like replacement, or a switch (which have implied additional costs, like decommissioning redundant system parts).
- Households have an estimated annual kwh heat demand, based on their floor area. Note that we ignore any impact of EPC for the time being. This aligns to some empirical studies which suggest households often increase energy usage after improving efficiency, to further increase comfort levels at the same cost.
- Households evaluate future fuel bills based on some number of "look ahead" years (defined at the model level). For example, while a heating system may last for 20 years, a household may evaluate changes to their costs over a shorter horizon (default: 3 years). Their valuation is also impacted by their own discount rate. Less wealthy households = higher discount rates = future cashflows have a lower present day value.