### PR TITLE
Households choose heating systems based on costs and hassle

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -48,8 +48,8 @@ def parse_args(args=None):
     parser.add_argument(
         "--heating-system-hassle-factor",
         type=restrict_between_0_and_1,
-        default=0.7,
-        help="A value between 0 and 1 which suppresses the likelihood of a household choosing a given heating system (the lower the value, the lower the likelihood)",
+        default=0.3,
+        help="A value between 0 and 1 which suppresses the likelihood of a household choosing a given heating system (the higher the value, the lower the likelihood)",
     )
 
     return parser.parse_args(args)

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -42,6 +42,16 @@ def parse_args(args=None):
         help="The number of years households look ahead when making purchasing decisions; any cash flows to be exchanged further than this number of years in the future are valued at £0 by households",
     )
 
+    def restrict_between_0_and_1(input_value: float):
+        return max(min(input_value, 0), 1)
+
+    parser.add_argument(
+        "--heating-system-hassle-factor",
+        type=restrict_between_0_and_1,
+        default=0.7,
+        help="A value between 0 and 1 which suppresses the likelihood of a household choosing a given heating system (the lower the value, the lower the likelihood)",
+    )
+
     return parser.parse_args(args)
 
 
@@ -57,6 +67,7 @@ if __name__ == "__main__":
         args.heat_pump_awareness,
         args.annual_renovation_rate,
         args.household_num_lookahead_years,
+        args.heating_system_hassle_factor,
     )
 
     write_jsonlines(history, args.history_filename)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -310,12 +310,19 @@ class Household(Agent):
 
         return insulation_quotes
 
-    def choose_n_elements_to_insulate(self) -> int:
+    def get_num_insulation_elements(self, event_trigger: EventTrigger) -> int:
 
-        # Derived from the VERD Project, 2012-2013. UK Data Service. SN: 7773, http://doi.org/10.5255/UKDA-SN-7773-1
-        # Based upon the choices of houses in 'Stage 3' - finalising or actively renovating
+        if event_trigger == EventTrigger.RENOVATION:
+            # Derived from the VERD Project, 2012-2013. UK Data Service. SN: 7773, http://doi.org/10.5255/UKDA-SN-7773-1
+            # Based upon the choices of houses in 'Stage 3' - finalising or actively renovating
+            return random.choices([1, 2, 3], weights=[0.76, 0.17, 0.07])[0]
 
-        return random.choices([1, 2, 3], weights=[0.76, 0.17, 0.07])[0]
+        if event_trigger == EventTrigger.EPC_C_UPGRADE:
+            # The number of insulation elements a household would require to reach epc C
+            # We assume each insulation measure will contribute +1 EPC grade
+            return max(0, self.epc.value - Epc.C.value)
+
+        return 0
 
     def choose_insulation_elements(
         self, insulation_quotes: Dict[Element, float], num_elements: int

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -108,6 +108,7 @@ DISCOUNT_RATE_WEIBULL_BETA = 0.165
 class EventTrigger(enum.Enum):
     BREAKDOWN = 0
     RENOVATION = 1
+    EPC_C_UPGRADE = 2
 
 
 # Scale factor is inferred from general relationship between estimated floor area and kW capacity

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -25,6 +25,7 @@ class CnzAgentBasedModel(AgentBasedModel):
         step_interval,
         annual_renovation_rate,
         household_num_lookahead_years,
+        heating_system_hassle_factor,
     ):
         self.start_datetime = start_datetime
         self.step_interval = step_interval
@@ -32,6 +33,7 @@ class CnzAgentBasedModel(AgentBasedModel):
         self.annual_renovation_rate = annual_renovation_rate
         self.heating_systems = set(HeatingSystem)
         self.household_num_lookahead_years = household_num_lookahead_years
+        self.heating_system_hassle_factor = heating_system_hassle_factor
 
         super().__init__(UnorderedSpace())
 
@@ -84,12 +86,14 @@ def create_and_run_simulation(
     heat_pump_awareness: float,
     annual_renovation_rate: float,
     household_num_lookahead_years: int,
+    heating_system_hassle_factor: float,
 ):
     model = CnzAgentBasedModel(
         start_datetime=start_datetime,
         step_interval=step_interval,
         annual_renovation_rate=annual_renovation_rate,
         household_num_lookahead_years=household_num_lookahead_years,
+        heating_system_hassle_factor=heating_system_hassle_factor,
     )
 
     households = create_households(

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -42,5 +42,6 @@ def model_factory(**model_attributes):
         "step_interval": datetime.timedelta(minutes=1440),
         "annual_renovation_rate": 0.05,
         "household_num_lookahead_years": 3,
+        "heating_system_hassle_factor": 0.7,
     }
     return CnzAgentBasedModel(**{**default_values, **model_attributes})

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -140,18 +140,36 @@ class TestHousehold:
     ) -> None:
 
         household = household_factory()
-        assert 0 < household.get_num_insulation_elements(event_trigger=EventTrigger.RENOVATION) <= 3
+        assert (
+            0
+            < household.get_num_insulation_elements(
+                event_trigger=EventTrigger.RENOVATION
+            )
+            <= 3
+        )
 
     @pytest.mark.parametrize("epc", list(Epc))
-    def test_num_insulation_measures_chosen_by_household_corresponding_to_current_epc_value(
-        self, epc,
+    def test_num_insulation_measures_chosen_by_household_corresponds_to_current_epc_value(
+        self,
+        epc,
     ) -> None:
 
         household = household_factory(epc=epc)
         if household.epc.value > Epc.C.value:
-            assert household.get_num_insulation_elements(event_trigger=EventTrigger.EPC_C_UPGRADE) > 0
+            expected_insulation_elements = epc.value - Epc.C.value
+            assert (
+                household.get_num_insulation_elements(
+                    event_trigger=EventTrigger.EPC_C_UPGRADE
+                )
+                == expected_insulation_elements
+            )
         if household.epc.value <= Epc.C.value:
-            assert household.get_num_insulation_elements(event_trigger=EventTrigger.EPC_C_UPGRADE) == 0
+            assert (
+                household.get_num_insulation_elements(
+                    event_trigger=EventTrigger.EPC_C_UPGRADE
+                )
+                == 0
+            )
 
     def test_household_chooses_cheapest_insulation_measures(
         self,
@@ -393,3 +411,26 @@ class TestHousehold:
             household_with_heat_pump.annual_kwh_heating_demand
             < household_with_gas_boiler.annual_kwh_heating_demand
         )
+
+    @pytest.mark.parametrize("epc", list(Epc))
+    def test_household_choses_insulation_elements_at_epc_C_upgrade_event_if_current_epc_worse_than_C(
+        self,
+        epc,
+    ) -> None:
+
+        household = household_factory(epc=epc)
+
+        if epc.value <= Epc.C.value:
+            assert (
+                household.get_chosen_insulation_costs(
+                    event_trigger=EventTrigger.EPC_C_UPGRADE
+                )
+                == {}
+            )
+
+        if epc.value > Epc.C.value:
+            chosen_insulation_elements = household.get_chosen_insulation_costs(
+                event_trigger=EventTrigger.EPC_C_UPGRADE
+            )
+
+            assert chosen_insulation_elements

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -135,12 +135,23 @@ class TestHousehold:
         assert set(insulation_quotes.keys()) == upgradable_elements
         assert all(quote > 0 for quote in insulation_quotes.values())
 
-    def test_household_chooses_one_to_three_insulation_measures_to_install(
+    def test_household_chooses_one_to_three_insulation_measures_to_install_at_renovation(
         self,
     ) -> None:
 
         household = household_factory()
-        assert 0 < household.choose_n_elements_to_insulate() <= 3
+        assert 0 < household.get_num_insulation_elements(event_trigger=EventTrigger.RENOVATION) <= 3
+
+    @pytest.mark.parametrize("epc", list(Epc))
+    def test_num_insulation_measures_chosen_by_household_corresponding_to_current_epc_value(
+        self, epc,
+    ) -> None:
+
+        household = household_factory(epc=epc)
+        if household.epc.value > Epc.C.value:
+            assert household.get_num_insulation_elements(event_trigger=EventTrigger.EPC_C_UPGRADE) > 0
+        if household.epc.value <= Epc.C.value:
+            assert household.get_num_insulation_elements(event_trigger=EventTrigger.EPC_C_UPGRADE) == 0
 
     def test_household_chooses_cheapest_insulation_measures(
         self,

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -17,6 +17,7 @@ from simulation.constants import (
     HeatingSystem,
     OccupantType,
     PropertyType,
+    BOILERS,
 )
 from simulation.tests.common import household_factory, model_factory
 
@@ -434,3 +435,24 @@ class TestHousehold:
             )
 
             assert chosen_insulation_elements
+
+    @pytest.mark.parametrize("heating_system", list(HeatingSystem))
+    def test_heating_system_is_not_hassle_if_already_installed_or_a_boiler(
+        self,
+        heating_system,
+    ) -> None:
+
+        household = household_factory(heating_system=heating_system)
+        if heating_system == household.heating_system:
+            assert not household.is_heating_system_hassle(heating_system)
+        if heating_system in BOILERS:
+            assert not household.is_heating_system_hassle(heating_system)
+
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_heat_pumps_are_hassle_if_not_already_installed(
+        self,
+        heat_pump,
+    ) -> None:
+
+        household = household_factory(heating_system=random.choices(list(BOILERS))[0])
+        assert household.is_heating_system_hassle(heat_pump)

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from simulation.constants import (
+    BOILERS,
     HEAT_PUMPS,
     MAX_HEAT_PUMP_CAPACITY_KW,
     MIN_HEAT_PUMP_CAPACITY_KW,
@@ -17,7 +18,6 @@ from simulation.constants import (
     HeatingSystem,
     OccupantType,
     PropertyType,
-    BOILERS,
 )
 from simulation.tests.common import household_factory, model_factory
 
@@ -456,3 +456,20 @@ class TestHousehold:
 
         household = household_factory(heating_system=random.choices(list(BOILERS))[0])
         assert household.is_heating_system_hassle(heat_pump)
+
+    @pytest.mark.parametrize("heating_system", list(HeatingSystem))
+    def test_heat_pumps_never_selected_if_hassle_factor_is_one_and_not_currently_installed(
+        self,
+        heating_system,
+    ) -> None:
+
+        household = household_factory(heating_system=HeatingSystem.BOILER_GAS)
+        costs = {
+            HeatingSystem.BOILER_GAS: 2_000,
+            HeatingSystem.HEAT_PUMP_AIR_SOURCE: 2_000,
+        }
+
+        assert (
+            household.choose_heating_system(costs, heating_system_hassle_factor=1)
+            == HeatingSystem.BOILER_GAS
+        )


### PR DESCRIPTION
- `EventTrigger.EPC_C_UPGRADE` added, which is associated with particular count of insulation upgrade requirements to reach EPC C (unlike a renovation event)
- Update household methods to choose number of insulation elements - to accept an event_trigger and return different output depending on whether an `EventTrigger.RENOVATION` or `EventTrigger.EPC_C_UPGRADE`
- Update model to accept `heating_system_hassle_factor`, which suppresses likelihood of a "hassle-y" heating system being chosen by a household
- Add household methods to get total heating system costs, get chosen insulation element costs, evaluate whether a heating system is a "hassle" or not, and choose a heating system (based on costs + hassle)
- Update `household.step()` to reflect the above