### PR TITLE
Add fuller simulation tracking

### DIFF
--- a/abm.py
+++ b/abm.py
@@ -84,7 +84,6 @@ class AgentBasedModel:
                 agent_datum = {
                     agent_callable.__name__: agent_callable(agent)
                     for agent_callable in agent_callables
-                    if agent_callable(agent)
                 }
                 agent_data.append(agent_datum)
 

--- a/abm.py
+++ b/abm.py
@@ -84,6 +84,7 @@ class AgentBasedModel:
                 agent_datum = {
                     agent_callable.__name__: agent_callable(agent)
                     for agent_callable in agent_callables
+                    if agent_callable(agent) is not None
                 }
                 agent_data.append(agent_datum)
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -99,8 +99,12 @@ class Household(Agent):
         self.windows_energy_efficiency = windows_energy_efficiency
         self.is_heat_pump_aware = is_heat_pump_aware
 
-        # Renovation attributes
+        # Household investment decision attributes
         self.is_renovating = False
+        self.renovate_insulation = False
+        self.renovate_heating_system = False
+        self.epc_c_upgrade_costs = {}
+        self.heating_system_total_costs = {}
 
     @property
     def heating_fuel(self) -> HeatingFuel:
@@ -429,6 +433,9 @@ class Household(Agent):
 
     def update_heating_status(self, model: "CnzAgentBasedModel") -> None:
 
+        self.epc_c_upgrade_costs = {}
+        self.heating_system_total_costs = {}
+
         step_interval_years = model.step_interval / datetime.timedelta(days=365)
         probability_density = self.weibull_hazard_rate(
             HAZARD_RATE_HEATING_SYSTEM_ALPHA,
@@ -486,6 +493,9 @@ class Household(Agent):
                 )
                 if heating_system in HEAT_PUMPS:
                     costs[heating_system] += sum(chosen_insulation_costs.values())
+
+            self.heating_system_total_costs = costs
+            self.epc_c_upgrade_costs = chosen_insulation_costs
 
             chosen_heating_system = self.choose_heating_system(
                 costs, model.heating_system_hassle_factor

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -280,10 +280,16 @@ class Household(Agent):
         PROBA_HEATING_SYSTEM_UPDATE = 0.18
         PROBA_INSULATION_UPDATE = 0.33
 
-        self.renovate_heating_system = self.true_with_probability(
-            PROBA_HEATING_SYSTEM_UPDATE
+        self.renovate_heating_system = (
+            self.true_with_probability(PROBA_HEATING_SYSTEM_UPDATE)
+            if self.is_renovating
+            else False
         )
-        self.renovate_insulation = self.true_with_probability(PROBA_INSULATION_UPDATE)
+        self.renovate_insulation = (
+            self.true_with_probability(PROBA_INSULATION_UPDATE)
+            if self.is_renovating
+            else False
+        )
 
     def get_upgradable_insulation_elements(self) -> Set[Element]:
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -46,6 +46,7 @@ from simulation.costs import (
     LOFT_INSULATION_JOISTS_COST,
     get_heating_fuel_costs_net_present_value,
     get_unit_and_install_costs,
+    HEATING_FUEL_PRICE_GBP_PER_KWH,
 )
 
 
@@ -247,6 +248,11 @@ class Household(Agent):
         return (
             self.floor_area_sqm * HEATING_KWH_PER_SQM_ANNUAL
         ) / FUEL_KWH_TO_HEAT_KWH[self.heating_system]
+
+    @property
+    def annual_heating_fuel_bill(self) -> int:
+
+        return int(self.annual_kwh_heating_demand * HEATING_FUEL_PRICE_GBP_PER_KWH[HEATING_SYSTEM_FUEL[self.heating_system]])
 
     def heating_system_age_years(self, current_date: datetime.date) -> float:
         return (current_date - self.heating_system_install_date).days / 365

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Callable, List
 
 from abm import collect_when
 from simulation.agents import Household
+from simulation.constants import Element, HeatingSystem
 
 if TYPE_CHECKING:
     from simulation.model import CnzAgentBasedModel
@@ -12,8 +13,152 @@ def household_id(household) -> int:
     return id(household)
 
 
+def household_location(household) -> str:
+    return household.location
+
+
+def household_property_value(household) -> int:
+    return household.property_value
+
+
+def household_floor_area_sqm(household) -> int:
+    return household.floor_area_sqm
+
+
+def household_off_gas_grid(household) -> bool:
+    return household.off_gas_grid
+
+
+def household_construction_year_band(household) -> str:
+    return household.construction_year_band.name
+
+
+def household_property_type(household) -> str:
+    return household.property_type.name
+
+
+def household_built_form(household) -> str:
+    return household.built_form.name
+
+
 def household_heating_system(household) -> str:
     return household.heating_system.name
+
+
+def household_heating_install_date(household) -> datetime.date:
+    return household.heating_system_install_date
+
+
+def household_epc(household) -> str:
+    return household.epc.name
+
+
+def household_potential_epc(household) -> str:
+    return household.potential_epc.name
+
+
+def household_occupant_type(household) -> str:
+    return household.occupant_type.name
+
+
+def household_is_solid_wall(household) -> bool:
+    return household.is_solid_wall
+
+
+def household_walls_energy_efficiency(household) -> int:
+    return household.walls_energy_efficiency
+
+
+def household_windows_energy_efficiency(household) -> int:
+    return household.windows_energy_efficiency
+
+
+def household_roof_energy_efficiency(household) -> int:
+    return household.roof_energy_efficiency
+
+
+def household_is_heat_pump_suitable_archetype(household) -> bool:
+    return household.is_heat_pump_suitable_archetype
+
+
+def household_is_heat_pump_aware(household) -> bool:
+    return household.is_heat_pump_aware
+
+
+def household_is_renovating(household) -> bool:
+    return household.is_renovating
+
+
+def household_is_renovating_insulation(household) -> bool:
+    return household.renovate_insulation
+
+
+def household_is_renovating_heating_system(household) -> bool:
+    return household.renovate_heating_system
+
+
+def household_wealth_percentile(household) -> float:
+    return household.wealth_percentile
+
+
+def household_discount_rate(household) -> float:
+    return household.discount_rate
+
+
+def household_renovation_budget(household) -> int:
+    return int(household.renovation_budget)
+
+
+def household_is_heat_pump_suitable(household) -> bool:
+    return household.is_heat_pump_suitable
+
+
+def household_annual_kwh_heating_demand(household) -> int:
+    return int(household.annual_kwh_heating_demand)
+
+
+def household_annual_heating_fuel_bill(household) -> int:
+    return household.annual_heating_fuel_bill
+
+
+def household_epc_c_upgrade_cost_roof(household) -> int:
+    return int(household.epc_c_upgrade_costs.get(Element.ROOF) or 0)
+
+
+def household_epc_c_upgrade_cost_walls(household) -> int:
+    return int(household.epc_c_upgrade_costs.get(Element.WALLS) or 0)
+
+
+def household_epc_c_upgrade_cost_windows(household) -> int:
+    return int(household.epc_c_upgrade_costs.get(Element.GLAZING) or 0)
+
+
+def household_heating_system_total_cost_boiler_gas(household) -> int:
+    return int(household.heating_system_total_costs.get(HeatingSystem.BOILER_GAS) or 0)
+
+
+def household_heating_system_total_cost_boiler_oil(household) -> int:
+    return int(household.heating_system_total_costs.get(HeatingSystem.BOILER_OIL) or 0)
+
+
+def household_heating_system_total_cost_boiler_electric(household) -> int:
+    return int(
+        household.heating_system_total_costs.get(HeatingSystem.BOILER_ELECTRIC) or 0
+    )
+
+
+def household_heating_system_total_cost_heat_pump_air_source(household) -> int:
+    return int(
+        household.heating_system_total_costs.get(HeatingSystem.HEAT_PUMP_AIR_SOURCE)
+        or 0
+    )
+
+
+def household_heating_system_total_cost_heat_pump_ground_source(household) -> int:
+    return int(
+        household.heating_system_total_costs.get(HeatingSystem.HEAT_PUMP_GROUND_SOURCE)
+        or 0
+    )
 
 
 def model_current_datetime(model) -> datetime.datetime:
@@ -28,8 +173,42 @@ def get_agent_collectors(
     model: "CnzAgentBasedModel",
 ) -> List[Callable[[Household], Any]]:
     return [
-        collect_when(model, is_first_step)(household_id),
+        household_id,
+        collect_when(model, is_first_step)(household_location),
+        collect_when(model, is_first_step)(household_property_value),
+        collect_when(model, is_first_step)(household_floor_area_sqm),
+        collect_when(model, is_first_step)(household_off_gas_grid),
+        collect_when(model, is_first_step)(household_construction_year_band),
+        collect_when(model, is_first_step)(household_property_type),
+        collect_when(model, is_first_step)(household_built_form),
+        collect_when(model, is_first_step)(household_potential_epc),
+        collect_when(model, is_first_step)(household_occupant_type),
+        collect_when(model, is_first_step)(household_is_solid_wall),
+        collect_when(model, is_first_step)(household_is_heat_pump_suitable_archetype),
+        collect_when(model, is_first_step)(household_wealth_percentile),
+        collect_when(model, is_first_step)(household_discount_rate),
+        collect_when(model, is_first_step)(household_renovation_budget),
+        collect_when(model, is_first_step)(household_is_heat_pump_suitable),
+        collect_when(model, is_first_step)(household_is_heat_pump_aware),
         household_heating_system,
+        household_heating_install_date,
+        household_epc,
+        household_walls_energy_efficiency,
+        household_windows_energy_efficiency,
+        household_roof_energy_efficiency,
+        household_is_renovating,
+        household_is_renovating_insulation,
+        household_is_renovating_heating_system,
+        household_annual_kwh_heating_demand,
+        household_annual_heating_fuel_bill,
+        household_epc_c_upgrade_cost_roof,
+        household_epc_c_upgrade_cost_walls,
+        household_epc_c_upgrade_cost_windows,
+        household_heating_system_total_cost_boiler_gas,
+        household_heating_system_total_cost_boiler_oil,
+        household_heating_system_total_cost_boiler_electric,
+        household_heating_system_total_cost_heat_pump_air_source,
+        household_heating_system_total_cost_heat_pump_ground_source,
     ]
 
 

--- a/tests/test_abm.py
+++ b/tests/test_abm.py
@@ -73,41 +73,34 @@ class TestAgentBasedModel:
 
             assert model["model_counter"] == step_num + 1
 
-    def test_run_yields_data_if_it_is_not_none(self) -> None:
+    def test_run_yields_data_if_agent_callable_evaluates_to_false(self) -> None:
         class HouseholdAgent(Agent):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self.attribute1 = None
-                self.attribute2 = "string"
+                self.bool_value = False
 
             def step(self, model=None):
                 pass
 
-        def agent_callable_returning_none(agent):
-            return agent.attribute1
-
-        def agent_callable_returning_string(agent):
-            return agent.attribute2
+        def agent_callable_returning_false(agent):
+            return agent.bool_value
 
         model = AgentBasedModel()
         model.add_agents([HouseholdAgent(), HouseholdAgent(), HouseholdAgent()])
         num_steps = 10
 
         history = model.run(
-            num_steps=num_steps, agent_callables=[agent_callable_returning_none]
+            num_steps=num_steps, agent_callables=[agent_callable_returning_false]
         )
 
         for step_num, step in enumerate(history):
             agents, _ = step
-            assert all([value == {} for value in agents])
-
-        history = model.run(
-            num_steps=num_steps, agent_callables=[agent_callable_returning_string]
-        )
-
-        for step_num, step in enumerate(history):
-            agents, _ = step
-            assert all([value != {} for value in agents])
+            assert all(
+                [
+                    agent_datum["agent_callable_returning_false"] is False
+                    for agent_datum in agents
+                ]
+            )
 
 
 def test_collect_when() -> None:

--- a/tests/test_abm.py
+++ b/tests/test_abm.py
@@ -73,6 +73,42 @@ class TestAgentBasedModel:
 
             assert model["model_counter"] == step_num + 1
 
+    def test_run_yields_data_if_it_is_not_none(self) -> None:
+        class HouseholdAgent(Agent):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.attribute1 = None
+                self.attribute2 = "string"
+
+            def step(self, model=None):
+                pass
+
+        def agent_callable_returning_none(agent):
+            return agent.attribute1
+
+        def agent_callable_returning_string(agent):
+            return agent.attribute2
+
+        model = AgentBasedModel()
+        model.add_agents([HouseholdAgent(), HouseholdAgent(), HouseholdAgent()])
+        num_steps = 10
+
+        history = model.run(
+            num_steps=num_steps, agent_callables=[agent_callable_returning_none]
+        )
+
+        for step_num, step in enumerate(history):
+            agents, _ = step
+            assert all([value == {} for value in agents])
+
+        history = model.run(
+            num_steps=num_steps, agent_callables=[agent_callable_returning_string]
+        )
+
+        for step_num, step in enumerate(history):
+            agents, _ = step
+            assert all([value != {} for value in agents])
+
 
 def test_collect_when() -> None:
     class DateABM(AgentBasedModel):

--- a/tests/test_abm.py
+++ b/tests/test_abm.py
@@ -77,10 +77,14 @@ class TestAgentBasedModel:
         class HouseholdAgent(Agent):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
+                self.empty_value = None
                 self.bool_value = False
 
             def step(self, model=None):
                 pass
+
+        def agent_callable_returning_none(agent):
+            return agent.empty_value
 
         def agent_callable_returning_false(agent):
             return agent.bool_value
@@ -90,17 +94,22 @@ class TestAgentBasedModel:
         num_steps = 10
 
         history = model.run(
+            num_steps=num_steps, agent_callables=[agent_callable_returning_none]
+        )
+
+        for step_num, step in enumerate(history):
+            agents, _ = step
+            for agent in agents:
+                assert agent == {}
+
+        history = model.run(
             num_steps=num_steps, agent_callables=[agent_callable_returning_false]
         )
 
         for step_num, step in enumerate(history):
             agents, _ = step
-            assert all(
-                [
-                    agent_datum["agent_callable_returning_false"] is False
-                    for agent_datum in agents
-                ]
-            )
+            for agent in agents:
+                assert agent == {"agent_callable_returning_false": False}
 
 
 def test_collect_when() -> None:


### PR DESCRIPTION
- Add various household collectors for more comprehensive simulation tracking 
- Small modifications to household methods to resolve consistency issues and bugs observed during analysis of simulation output, or to add various household attributes for simulation logging (e.g. prices of heating types seen at a heating decision)
- modify `AgentBasedModel.run()` so agent_callables which evaluate to `False` (e.g. `is_renovating`) are stored as  `False` (and not `None`) in the agent's history