### PR TITLE
Update heating system costs (installation, re-installation, and min. heat pump capacity required)

### DIFF
--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -126,8 +126,8 @@ MAX_HEAT_PUMP_CAPACITY_KW = {
 }
 
 MIN_HEAT_PUMP_CAPACITY_KW = {
-    HeatingSystem.HEAT_PUMP_AIR_SOURCE: 2.0,
-    HeatingSystem.HEAT_PUMP_GROUND_SOURCE: 2.0,
+    HeatingSystem.HEAT_PUMP_AIR_SOURCE: 4.0,
+    HeatingSystem.HEAT_PUMP_GROUND_SOURCE: 4.0,
 }
 
 

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -84,3 +84,17 @@ class TestCosts:
         ) < get_heating_fuel_costs_net_present_value(
             wealthier_household, heating_system, num_look_ahead_years
         )
+
+    @pytest.mark.parametrize("heat_pump", set(HEAT_PUMPS))
+    def test_heat_pumps_are_cheaper_to_reinstall_than_install_first_time(
+        self,
+        heat_pump,
+    ) -> None:
+
+        household = household_factory(heating_system=HeatingSystem.BOILER_GAS)
+        new_heat_pump_quote = get_unit_and_install_costs(household, heat_pump)
+
+        household.heating_system = heat_pump
+        reinstall_heat_pump_quote = get_unit_and_install_costs(household, heat_pump)
+
+        assert reinstall_heat_pump_quote < new_heat_pump_quote


### PR DESCRIPTION
- Adds a fixed constant cost for boiler installation, as the existing figures reflect the costs of the unit only.
- Updates the minimum KW capacity of heat pumps installed in practice, reflecting advice from heat pump installation experts consulted
- Adds factors which discount the costs of 2nd+ time heat pump installs -- as the figures reflect "first time" installation costs like pipework, radiator upgrades and drilling boreholes which will not apply to a repurchase of the same heat pump system. This is particularly true of ground source heat pumps.