### PR TITLE
Reorder epc enum class so EPC A takes highest value

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -226,7 +226,7 @@ class Household(Agent):
             if not all(
                 [
                     self.is_heat_pump_suitable_archetype,
-                    self.potential_epc.value <= Epc.C.value,
+                    self.potential_epc.value >= Epc.C.value,
                 ]
             )
             else True
@@ -320,7 +320,7 @@ class Household(Agent):
         if event_trigger == EventTrigger.EPC_C_UPGRADE:
             # The number of insulation elements a household would require to reach epc C
             # We assume each insulation measure will contribute +1 EPC grade
-            return max(0, self.epc.value - Epc.C.value)
+            return max(0, Epc.C.value - self.epc.value)
 
         return 0
 
@@ -370,7 +370,7 @@ class Household(Agent):
                 self.windows_energy_efficiency = 5
 
         n_measures = len(insulation_elements)
-        improved_epc_level = max(0, self.epc.value - n_measures)
+        improved_epc_level = min(6, self.epc.value + n_measures)
         self.epc = Epc(improved_epc_level)
 
     def get_chosen_insulation_costs(self, event_trigger: EventTrigger):

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -22,13 +22,13 @@ class OccupantType(enum.Enum):
 
 
 class Epc(enum.Enum):
-    A = 0
-    B = 1
-    C = 2
+    G = 0
+    F = 1
+    E = 2
     D = 3
-    E = 4
-    F = 5
-    G = 6
+    C = 4
+    B = 5
+    A = 6
 
 
 class HeatingSystem(enum.Enum):

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -157,15 +157,15 @@ class TestHousehold:
     ) -> None:
 
         household = household_factory(epc=epc)
-        if household.epc.value > Epc.C.value:
-            expected_insulation_elements = epc.value - Epc.C.value
+        if household.epc.value < Epc.C.value:
+            expected_insulation_elements = Epc.C.value - epc.value
             assert (
                 household.get_num_insulation_elements(
                     event_trigger=EventTrigger.EPC_C_UPGRADE
                 )
                 == expected_insulation_elements
             )
-        if household.epc.value <= Epc.C.value:
+        if household.epc.value >= Epc.C.value:
             assert (
                 household.get_num_insulation_elements(
                     event_trigger=EventTrigger.EPC_C_UPGRADE
@@ -442,7 +442,7 @@ class TestHousehold:
 
         household = household_factory(epc=epc)
 
-        if epc.value <= Epc.C.value:
+        if epc.value >= Epc.C.value:
             assert (
                 household.get_chosen_insulation_costs(
                     event_trigger=EventTrigger.EPC_C_UPGRADE
@@ -450,7 +450,7 @@ class TestHousehold:
                 == {}
             )
 
-        if epc.value > Epc.C.value:
+        if epc.value < Epc.C.value:
             chosen_insulation_elements = household.get_chosen_insulation_costs(
                 event_trigger=EventTrigger.EPC_C_UPGRADE
             )


### PR DESCRIPTION
- Reorder `class Epc(enum.Enum)`, so value increases as EPC increases
- Refactor associated logic that makes use of epc enum values