### PR TITLE
Add RHI intervention to support simulation validation over historical periods

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -52,6 +52,12 @@ def parse_args(args=None):
         help="A value between 0 and 1 which suppresses the likelihood of a household choosing a given heating system (the higher the value, the lower the likelihood)",
     )
 
+    parser.add_argument(
+        "--intervention",
+        choices=["rhi"],
+        type=str,
+    )
+
     return parser.parse_args(args)
 
 
@@ -68,6 +74,7 @@ if __name__ == "__main__":
         args.annual_renovation_rate,
         args.household_num_lookahead_years,
         args.heating_system_hassle_factor,
+        args.intervention,
     )
 
     write_jsonlines(history, args.history_filename)

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -188,3 +188,7 @@ RETROFIT_COSTS_SMALL_PROPERTY_SQM_LIMIT = {
 # Source: England/Wales Energy Performance Certificates
 FLOOR_AREA_SQM_33RD_PERCENTILE = 66
 FLOOR_AREA_SQM_66TH_PERCENTILE = 89
+
+
+class InterventionType(enum.Enum):
+    RHI = 0

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -13,6 +13,7 @@ from simulation.constants import (
     ConstructionYearBand,
     Epc,
     HeatingSystem,
+    InterventionType,
     OccupantType,
     PropertyType,
 )
@@ -26,6 +27,7 @@ class DomesticHeatingABM(AgentBasedModel):
         annual_renovation_rate,
         household_num_lookahead_years,
         heating_system_hassle_factor,
+        intervention,
     ):
         self.start_datetime = start_datetime
         self.step_interval = step_interval
@@ -34,6 +36,9 @@ class DomesticHeatingABM(AgentBasedModel):
         self.heating_systems = set(HeatingSystem)
         self.household_num_lookahead_years = household_num_lookahead_years
         self.heating_system_hassle_factor = heating_system_hassle_factor
+        self.intervention = (
+            InterventionType[intervention.upper()] if intervention else None
+        )
 
         super().__init__(UnorderedSpace())
 
@@ -87,6 +92,7 @@ def create_and_run_simulation(
     annual_renovation_rate: float,
     household_num_lookahead_years: int,
     heating_system_hassle_factor: float,
+    intervention: str,
 ):
     model = DomesticHeatingABM(
         start_datetime=start_datetime,
@@ -94,6 +100,7 @@ def create_and_run_simulation(
         annual_renovation_rate=annual_renovation_rate,
         household_num_lookahead_years=household_num_lookahead_years,
         heating_system_hassle_factor=heating_system_hassle_factor,
+        intervention=intervention,
     )
 
     households = create_households(

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -43,5 +43,6 @@ def model_factory(**model_attributes):
         "annual_renovation_rate": 0.05,
         "household_num_lookahead_years": 3,
         "heating_system_hassle_factor": 0.7,
+        "intervention": None,
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -513,3 +513,17 @@ class TestHousehold:
         assert household.heating_system == heating_system
         assert household.heating_functioning
         assert household.heating_system_install_date == model.current_datetime.date()
+
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_total_heating_system_costs_are_lower_for_heat_pumps_if_model_intervention_rhi(
+        self, heat_pump
+    ):
+
+        household = household_factory(heating_system=random.choices(list(BOILERS))[0])
+
+        model_without_rhi = model_factory()
+        model_with_rhi = model_factory(intervention="rhi")
+
+        assert household.get_total_heating_system_costs(
+            heat_pump, model_with_rhi
+        ) < household.get_total_heating_system_costs(heat_pump, model_without_rhi)


### PR DESCRIPTION
In order to reconcile the outputs of the ABM against historical uptake, we need to reflect the conditions of the Domestic RHI in the ABM, which has been live since April 2014 (https://www.ofgem.gov.uk/environmental-and-social-schemes/domestic-renewable-heat-incentive-domestic-rhi). This PR:

- Adds a function to calculate the payments that households would be likely to receive under the RHI
- Passes an intervention label as a command line arg to the model
- Updates a household's method to compute total cost of a given heating system, to subtract any relevant subsidy