### PR TITLE
ASHP costs are linearly discounted up to a user-specified factor by the end of 2022

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -58,6 +58,13 @@ def parse_args(args=None):
         type=str,
     )
 
+    parser.add_argument(
+        "--air-source-heat-pump-discount-factor-2022",
+        type=float,
+        default=0.1,
+        help="A factor by which air source heat pump unit+install costs will decline, in a linear fashion, by the end of 2022",
+    )
+
     return parser.parse_args(args)
 
 
@@ -75,6 +82,7 @@ if __name__ == "__main__":
         args.household_num_lookahead_years,
         args.heating_system_hassle_factor,
         args.intervention,
+        args.air_source_heat_pump_discount_factor_2022,
     )
 
     write_jsonlines(history, args.history_filename)

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -62,7 +62,7 @@ def parse_args(args=None):
         "--air-source-heat-pump-discount-factor-2022",
         type=float,
         default=0.1,
-        help="A factor by which air source heat pump unit+install costs will decline, in a linear fashion, by the end of 2022",
+        help="A factor by which current (2021) air source heat pump unit+install costs will have declined by, as of the end of 2022",
     )
 
     return parser.parse_args(args)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -417,7 +417,7 @@ class Household(Agent):
         model: "DomesticHeatingABM",
     ):
 
-        unit_and_install_costs = get_unit_and_install_costs(self, heating_system)
+        unit_and_install_costs = get_unit_and_install_costs(self, heating_system, model)
         fuel_costs_net_present_value = get_heating_fuel_costs_net_present_value(
             self, heating_system, model.household_num_lookahead_years
         )

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -14,6 +14,7 @@ from simulation.constants import (
 
 if TYPE_CHECKING:
     from simulation.agents import Household
+    from simulation.model import DomesticHeatingABM
 
 # Source: BEIS - WHAT DOES IT COST TO RETROFIT HOMES?
 
@@ -158,7 +159,9 @@ HEAT_PUMP_GROUND_SOURCE_REINSTALL_DISCOUNT = 0.5
 
 
 def get_unit_and_install_costs(
-    household: "Household", heating_system: HeatingSystem
+    household: "Household",
+    heating_system: HeatingSystem,
+    model: "DomesticHeatingABM",
 ) -> int:
 
     costs = 0
@@ -169,13 +172,18 @@ def get_unit_and_install_costs(
 
     if heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
         kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)
+        unit_and_install_costs = (
+            MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity]
+            * model.air_source_heat_pump_discount_factor
+        )
+
         if household.heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
             # Some installation work required to install a heat pump first time does not apply to 2nd+ installations
-            costs += MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity] * (
+            costs += unit_and_install_costs * (
                 1 - HEAT_PUMP_AIR_SOURCE_REINSTALL_DISCOUNT
             )
         else:
-            costs += MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity]
+            costs += unit_and_install_costs
 
     if heating_system == HeatingSystem.HEAT_PUMP_GROUND_SOURCE:
         kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -28,6 +28,7 @@ class DomesticHeatingABM(AgentBasedModel):
         household_num_lookahead_years,
         heating_system_hassle_factor,
         intervention,
+        air_source_heat_pump_discount_factor_2022,
     ):
         self.start_datetime = start_datetime
         self.step_interval = step_interval
@@ -39,8 +40,22 @@ class DomesticHeatingABM(AgentBasedModel):
         self.intervention = (
             InterventionType[intervention.upper()] if intervention else None
         )
+        self.air_source_heat_pump_discount_factor_2022 = (
+            air_source_heat_pump_discount_factor_2022
+        )
 
         super().__init__(UnorderedSpace())
+
+    @property
+    def air_source_heat_pump_discount_factor(self) -> float:
+
+        if self.current_datetime.year < 2022:
+            return 1
+        if self.current_datetime.year > 2022:
+            return self.air_source_heat_pump_discount_factor_2022
+        else:
+            month = self.current_datetime.month
+            return 1 - (month / 12 * self.air_source_heat_pump_discount_factor_2022)
 
     def increment_timestep(self):
         self.current_datetime += self.step_interval
@@ -93,7 +108,9 @@ def create_and_run_simulation(
     household_num_lookahead_years: int,
     heating_system_hassle_factor: float,
     intervention: str,
+    air_source_heat_pump_discount_factor_2022: float,
 ):
+
     model = DomesticHeatingABM(
         start_datetime=start_datetime,
         step_interval=step_interval,
@@ -101,6 +118,7 @@ def create_and_run_simulation(
         household_num_lookahead_years=household_num_lookahead_years,
         heating_system_hassle_factor=heating_system_hassle_factor,
         intervention=intervention,
+        air_source_heat_pump_discount_factor_2022=air_source_heat_pump_discount_factor_2022,
     )
 
     households = create_households(

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -52,7 +52,7 @@ class DomesticHeatingABM(AgentBasedModel):
         if self.current_datetime.year < 2022:
             return 1
         if self.current_datetime.year > 2022:
-            return self.air_source_heat_pump_discount_factor_2022
+            return 1 - self.air_source_heat_pump_discount_factor_2022
         else:
             month = self.current_datetime.month
             return 1 - (month / 12 * self.air_source_heat_pump_discount_factor_2022)

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -44,5 +44,6 @@ def model_factory(**model_attributes):
         "household_num_lookahead_years": 3,
         "heating_system_hassle_factor": 0.7,
         "intervention": None,
+        "air_source_heat_pump_discount_factor_2022": 0,
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -156,7 +156,6 @@ class TestCosts:
         household = household_factory(heating_system=HeatingSystem.HEAT_PUMP_AIR_SOURCE)
         model = model_factory(
             start_datetime=datetime.datetime(2022, 1, 1, 0, 0),
-            step_interval=datetime.timedelta(days=30),
             air_source_heat_pump_discount_factor_2022=0.3,
         )
         quote = get_unit_and_install_costs(
@@ -168,9 +167,9 @@ class TestCosts:
             future_quote = get_unit_and_install_costs(
                 household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
             )
-            if n <= 12:
+            if n < 12:
                 assert quote > future_quote
-            if n > 12:
+            if n >= 12:
                 assert quote == future_quote
 
             quote = future_quote

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -2,6 +2,7 @@ import datetime
 import random
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from simulation.constants import BOILERS, HEAT_PUMPS, HeatingSystem
 from simulation.costs import (
@@ -156,14 +157,20 @@ class TestCosts:
         model = model_factory(
             start_datetime=datetime.datetime(2022, 1, 1, 0, 0),
             step_interval=datetime.timedelta(days=30),
+            air_source_heat_pump_discount_factor_2022=0.3,
         )
-        initial_cost = get_unit_and_install_costs(
+        quote = get_unit_and_install_costs(
             household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
         )
 
-        for _ in range(0, 12):
-            model.increment_timestep()
-            future_cost = get_unit_and_install_costs(
+        for n in range(1, 24):
+            model.current_datetime += relativedelta(months=1)
+            future_quote = get_unit_and_install_costs(
                 household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
             )
-            assert initial_cost >= future_cost
+            if n <= 12:
+                assert quote > future_quote
+            if n > 12:
+                assert quote == future_quote
+
+            quote = future_quote


### PR DESCRIPTION
- Add discount factor to the model which represents the % by which current air source heat pump costs will have fallen, by the end of 2022. This factor linearly changes over the year 2022, reaching a user-specified or default value at the end of 2022.
- Modify cost calculations to reflect this discount factor
- Test that ASHP costs become cheaper across 2022 (when this discount factor is non-zero)

Note that this PR enables _deterministic_ ASHP price changes to be reflected in the simulation. A future PR could incorporate a learning rate calculation based upon the number of units sold in the simulation, if necessary.