### PR TITLE
Add fuller simulation tracking - prior heating system and functioning status

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -463,7 +463,6 @@ class Household(Agent):
 
         self.heating_system = heating_system
         self.heating_system_install_date = model.current_datetime.date()
-        self.heating_functioning = True
 
     def update_heating_status(self, model: "DomesticHeatingABM") -> None:
 
@@ -479,6 +478,8 @@ class Household(Agent):
         proba_failure = probability_density * step_interval_years
         if random.random() < proba_failure:
             self.heating_functioning = False
+        else:
+            self.heating_functioning = True
 
     def compute_heat_pump_capacity_kw(self, heat_pump_type: HeatingSystem) -> int:
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -103,7 +103,7 @@ class Household(Agent):
         self.is_off_gas_grid = is_off_gas_grid
         self.heating_functioning = True
         self.heating_system = heating_system
-        self.heating_system_prior = None
+        self.heating_system_previous = None
         self.heating_system_install_date = heating_system_install_date
         self.epc_rating = epc_rating
         self.potential_epc_rating = potential_epc_rating
@@ -462,7 +462,7 @@ class Household(Agent):
         self, heating_system: HeatingSystem, model: "DomesticHeatingABM"
     ) -> None:
 
-        self.heating_system_prior = self.heating_system
+        self.heating_system_previous = self.heating_system
         self.heating_system = heating_system
         self.heating_system_install_date = model.current_datetime.date()
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -103,6 +103,7 @@ class Household(Agent):
         self.is_off_gas_grid = is_off_gas_grid
         self.heating_functioning = True
         self.heating_system = heating_system
+        self.heating_system_prior = None
         self.heating_system_install_date = heating_system_install_date
         self.epc_rating = epc_rating
         self.potential_epc_rating = potential_epc_rating
@@ -461,6 +462,7 @@ class Household(Agent):
         self, heating_system: HeatingSystem, model: "DomesticHeatingABM"
     ) -> None:
 
+        self.heating_system_prior = self.heating_system
         self.heating_system = heating_system
         self.heating_system_install_date = model.current_datetime.date()
 

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Callable, List
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 from abm import collect_when
 from simulation.agents import Household
@@ -43,6 +43,12 @@ def household_built_form(household) -> str:
 
 def household_heating_system(household) -> str:
     return household.heating_system.name
+
+
+def household_heating_system_prior(household) -> Optional[str]:
+    return (
+        household.heating_system_prior.name if household.heating_system_prior else None
+    )
 
 
 def household_heating_functioning(household) -> bool:
@@ -197,6 +203,7 @@ def get_agent_collectors(
         collect_when(model, is_first_timestep)(household_is_heat_pump_suitable),
         collect_when(model, is_first_timestep)(household_is_heat_pump_aware),
         household_heating_system,
+        household_heating_system_prior,
         household_heating_functioning,
         household_heating_install_date,
         household_epc,

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -45,9 +45,11 @@ def household_heating_system(household) -> str:
     return household.heating_system.name
 
 
-def household_heating_system_prior(household) -> Optional[str]:
+def household_heating_system_previous(household) -> Optional[str]:
     return (
-        household.heating_system_prior.name if household.heating_system_prior else None
+        household.heating_system_previous.name
+        if household.heating_system_previous
+        else None
     )
 
 
@@ -203,7 +205,7 @@ def get_agent_collectors(
         collect_when(model, is_first_timestep)(household_is_heat_pump_suitable),
         collect_when(model, is_first_timestep)(household_is_heat_pump_aware),
         household_heating_system,
-        household_heating_system_prior,
+        household_heating_system_previous,
         household_heating_functioning,
         household_heating_install_date,
         household_epc,

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -45,6 +45,10 @@ def household_heating_system(household) -> str:
     return household.heating_system.name
 
 
+def household_heating_functioning(household) -> bool:
+    return household.heating_functioning
+
+
 def household_heating_install_date(household) -> datetime.date:
     return household.heating_system_install_date
 
@@ -193,6 +197,7 @@ def get_agent_collectors(
         collect_when(model, is_first_timestep)(household_is_heat_pump_suitable),
         collect_when(model, is_first_timestep)(household_is_heat_pump_aware),
         household_heating_system,
+        household_heating_functioning,
         household_heating_install_date,
         household_epc,
         household_walls_energy_efficiency,

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -506,7 +506,7 @@ class TestHousehold:
         )
 
     @pytest.mark.parametrize("heating_system", list(HeatingSystem))
-    def test_households_install_working_heating_systems_at_model_current_datetime(
+    def test_households_installs_heating_systems_at_model_current_datetime_and_heating_becomes_functioning(
         self,
         heating_system,
     ) -> None:
@@ -520,6 +520,10 @@ class TestHousehold:
 
         assert household.heating_system == heating_system
         assert household.heating_system_install_date == model.current_datetime.date()
+
+        household.update_heating_status(model)
+
+        assert household.heating_functioning
 
     @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
     def test_total_heating_system_costs_are_lower_for_heat_pumps_if_model_intervention_rhi(

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -519,7 +519,6 @@ class TestHousehold:
         household.install_heating_system(heating_system, model)
 
         assert household.heating_system == heating_system
-        assert household.heating_functioning
         assert household.heating_system_install_date == model.current_datetime.date()
 
     @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)


### PR DESCRIPTION
- Update of a household's heating system status is moved from `household.install_heating_system()` to `household.update_heating_status()`. This ensures that the model collector for this attribute will obtain value `False` for the step in which a household's heating system has broken down (previously, it is updated back to `True` before the step is completed). A related test around heating system installation is modified accordingly.
- Add household attribute `household_heating_system_prior`, which is initialised to `None`, and populated with a heating system at every time step after a household has changed heating system. This is to facilitate downstream analyses on breakdown events on very large files
- Add collectors for `household_heating_functioning` and `household_heating_system_prior`