### PR TITLE
add command line arg to override heat pump suitability to True for all households

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -62,8 +62,8 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "--override-heat-pump-suitability",
-        default=True,
+        "--all-agents-heat-pump-suitable",
+        default=False,
         type=bool,
         help="When True, 100% of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
     )
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         args.heating_system_hassle_factor,
         args.intervention,
         args.air_source_heat_pump_discount_factor_2022,
-        args.override_heat_pump_suitability,
+        args.all_agents_heat_pump_suitable,
     )
 
     write_jsonlines(history, args.history_file)

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -62,6 +62,13 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
+        "--override-heat-pump-suitability",
+        default=True,
+        type=bool,
+        help="When True, 100% of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
+    )
+
+    parser.add_argument(
         "--air-source-heat-pump-discount-factor-2022",
         type=float,
         default=0.1,
@@ -101,6 +108,7 @@ if __name__ == "__main__":
         args.heating_system_hassle_factor,
         args.intervention,
         args.air_source_heat_pump_discount_factor_2022,
+        args.override_heat_pump_suitability,
     )
 
     write_jsonlines(history, args.history_file)

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -111,7 +111,7 @@ def create_and_run_simulation(
     heating_system_hassle_factor: float,
     intervention: str,
     air_source_heat_pump_discount_factor_2022: float,
-    override_heat_pump_suitability: bool,
+    all_agents_heat_pump_suitable: bool,
 ):
 
     model = DomesticHeatingABM(
@@ -128,7 +128,7 @@ def create_and_run_simulation(
         household_population,
         heat_pump_awareness,
         model.start_datetime,
-        override_heat_pump_suitability,
+        all_agents_heat_pump_suitable,
     )
     model.add_agents(households)
 

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -65,7 +65,7 @@ def create_household_agents(
     household_population: pd.DataFrame,
     heat_pump_awareness: float,
     simulation_start_datetime: datetime.datetime,
-    override_heat_pump_suitability: bool,
+    all_agents_heat_pump_suitable: bool,
 ) -> Iterator[Household]:
     for household in household_population.itertuples():
         yield Household(
@@ -94,7 +94,7 @@ def create_household_agents(
             windows_energy_efficiency=household.windows_energy_efficiency,
             roof_energy_efficiency=household.roof_energy_efficiency,
             is_heat_pump_suitable_archetype=True
-            if override_heat_pump_suitability
+            if all_agents_heat_pump_suitable
             else household.is_heat_pump_suitable_archetype,
             is_heat_pump_aware=random.random() < heat_pump_awareness,
         )

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -65,6 +65,7 @@ def create_household_agents(
     household_population: pd.DataFrame,
     heat_pump_awareness: float,
     simulation_start_datetime: datetime.datetime,
+    override_heat_pump_suitability: bool,
 ) -> Iterator[Household]:
     for household in household_population.itertuples():
         yield Household(
@@ -92,7 +93,9 @@ def create_household_agents(
             walls_energy_efficiency=household.walls_energy_efficiency,
             windows_energy_efficiency=household.windows_energy_efficiency,
             roof_energy_efficiency=household.roof_energy_efficiency,
-            is_heat_pump_suitable_archetype=household.is_heat_pump_suitable_archetype,
+            is_heat_pump_suitable_archetype=True
+            if override_heat_pump_suitability
+            else household.is_heat_pump_suitable_archetype,
             is_heat_pump_aware=random.random() < heat_pump_awareness,
         )
 
@@ -108,6 +111,7 @@ def create_and_run_simulation(
     heating_system_hassle_factor: float,
     intervention: str,
     air_source_heat_pump_discount_factor_2022: float,
+    override_heat_pump_suitability: bool,
 ):
 
     model = DomesticHeatingABM(
@@ -124,6 +128,7 @@ def create_and_run_simulation(
         household_population,
         heat_pump_awareness,
         model.start_datetime,
+        override_heat_pump_suitability,
     )
     model.add_agents(households)
 

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -53,10 +53,12 @@ def test_create_household_agents() -> None:
     )
     heat_pump_awareness = 0.4
     simulation_start_datetime = datetime.datetime.now()
+    override_heat_pump_suitability = False
     household_agents = create_household_agents(
         household_population,
         heat_pump_awareness,
         simulation_start_datetime,
+        override_heat_pump_suitability,
     )
     household = next(household_agents)
 

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -53,12 +53,12 @@ def test_create_household_agents() -> None:
     )
     heat_pump_awareness = 0.4
     simulation_start_datetime = datetime.datetime.now()
-    override_heat_pump_suitability = False
+    all_agents_heat_pump_suitable = False
     household_agents = create_household_agents(
         household_population,
         heat_pump_awareness,
         simulation_start_datetime,
-        override_heat_pump_suitability,
+        all_agents_heat_pump_suitable,
     )
     household = next(household_agents)
 


### PR DESCRIPTION
- Setting this arg to `True` means that all households in the simulation will be initialised with `is_heat_pump_suitable_archetype=True`, instead of as per the source file (in which mid-terraced houses and flats are categorised as unsuitable)
- Doing so is important for downstream analyses on the possible ranges of outcomes, as HP suitability is a contested topic -- the source dataset represents a conservative estimate of suitability, while the override represents the most optimistic