### PR TITLE
amend household evaluation of perceived fuel costs for renters/landlords

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -417,6 +417,20 @@ class Household(Agent):
 
         return heating_system_options
 
+    def get_heating_fuel_costs(
+        self,
+        heating_system: HeatingSystem,
+        model: "DomesticHeatingABM",
+    ):
+
+        if self.occupant_type == OccupantType.OWNER_OCCUPIED:
+            return get_heating_fuel_costs_net_present_value(
+                self, heating_system, model.household_num_lookahead_years
+            )
+
+        # Fuel bills are generally paid by tenants; landlords/rented households will not consider fuel bill differences
+        return 0
+
     def get_total_heating_system_costs(
         self,
         heating_system: HeatingSystem,
@@ -424,8 +438,8 @@ class Household(Agent):
     ):
 
         unit_and_install_costs = get_unit_and_install_costs(self, heating_system, model)
-        fuel_costs_net_present_value = get_heating_fuel_costs_net_present_value(
-            self, heating_system, model.household_num_lookahead_years
+        fuel_costs_net_present_value = self.get_heating_fuel_costs(
+            heating_system, model
         )
 
         if model.intervention == InterventionType.RHI:

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -538,3 +538,25 @@ class TestHousehold:
         assert household.get_total_heating_system_costs(
             heat_pump, model_with_rhi
         ) < household.get_total_heating_system_costs(heat_pump, model_without_rhi)
+
+    @pytest.mark.parametrize("heating_system", list(HeatingSystem))
+    def test_heating_fuel_costs_appear_lower_for_landlords_than_owner_occupiers(
+        self, heating_system
+    ):
+
+        current_heating_system = random.choices(list(HeatingSystem))[0]
+
+        rented_household = household_factory(
+            occupant_type=OccupantType.RENTED_PRIVATE,
+            heating_system=current_heating_system,
+        )
+        owned_household = household_factory(
+            occupant_type=OccupantType.OWNER_OCCUPIED,
+            heating_system=current_heating_system,
+        )
+
+        model = model_factory()
+
+        assert rented_household.get_heating_fuel_costs(
+            heating_system, model
+        ) < owned_household.get_heating_fuel_costs(heating_system, model)


### PR DESCRIPTION
- Fuel bills are generally paid by tenants in the UK; this modifies the perceived fuel bill costs of every heating system such that landlords/rented households evaluate them to £0
- In this way, we might expect owned households to be more averse to heating systems associated with higher fuel bills / more receptive to heating systems associated with lower fuel bills
