### PR TITLE
Add boiler upgrade scheme intervention

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -59,7 +59,7 @@ def parse_args(args=None):
 
     parser.add_argument(
         "--intervention",
-        choices=["rhi"],
+        choices=["rhi", "boiler_upgrade_scheme"],
         type=str,
     )
 

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -173,8 +173,16 @@ def household_heating_system_total_cost_heat_pump_ground_source(household) -> in
     )
 
 
+def household_boiler_upgrade_grant_used(household) -> int:
+    return household.boiler_upgrade_grant_used
+
+
 def model_current_datetime(model) -> datetime.datetime:
     return model.current_datetime
+
+
+def model_boiler_upgrade_scheme_cumulative_spend_gbp(model) -> int:
+    return model.boiler_upgrade_scheme_cumulative_spend_gbp
 
 
 def is_first_timestep(model: "DomesticHeatingABM") -> bool:
@@ -225,9 +233,11 @@ def get_agent_collectors(
         household_heating_system_total_cost_boiler_electric,
         household_heating_system_total_cost_heat_pump_air_source,
         household_heating_system_total_cost_heat_pump_ground_source,
+        household_boiler_upgrade_grant_used,
     ]
 
 
 model_collectors = [
     model_current_datetime,
+    model_boiler_upgrade_scheme_cumulative_spend_gbp,
 ]

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -197,3 +197,4 @@ FLOOR_AREA_SQM_66TH_PERCENTILE = 89
 
 class InterventionType(enum.Enum):
     RHI = 0
+    BOILER_UPGRADE_SCHEME = 1

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 from typing import TYPE_CHECKING, Dict
 
@@ -296,3 +297,35 @@ def estimate_rhi_annual_payment(
     )
 
     return rhi_annual_payment_gbp
+
+
+def estimate_boiler_upgrade_scheme_grant(
+    heating_system: HeatingSystem,
+    model: "DomesticHeatingABM",
+):
+
+    if heating_system not in [
+        HeatingSystem.HEAT_PUMP_AIR_SOURCE,
+        HeatingSystem.HEAT_PUMP_GROUND_SOURCE,
+    ]:
+        return 0
+
+    boiler_upgrade_funding_cap_gbp = 450_000_000
+    if (
+        model.boiler_upgrade_scheme_cumulative_spend_gbp
+        > boiler_upgrade_funding_cap_gbp
+    ):
+        return 0
+
+    if (
+        not datetime.date(2022, 4, 1)
+        <= model.current_datetime.date()
+        < datetime.date(2025, 4, 1)
+    ):
+        return 0
+
+    if heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
+        return 5_000
+
+    if heating_system == HeatingSystem.HEAT_PUMP_GROUND_SOURCE:
+        return 6_000

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -43,6 +43,7 @@ class DomesticHeatingABM(AgentBasedModel):
         self.air_source_heat_pump_discount_factor_2022 = (
             air_source_heat_pump_discount_factor_2022
         )
+        self.boiler_upgrade_scheme_cumulative_spend_gbp = 0
 
         super().__init__(UnorderedSpace())
 
@@ -57,8 +58,21 @@ class DomesticHeatingABM(AgentBasedModel):
             month = self.current_datetime.month
             return 1 - (month / 12 * self.air_source_heat_pump_discount_factor_2022)
 
+    @property
+    def boiler_upgrade_scheme_spend_gbp(self) -> int:
+        return sum(
+            [
+                agent.boiler_upgrade_grant_used
+                for agent in self.space.agents
+                if isinstance(agent, Household)
+            ]
+        )
+
     def increment_timestep(self):
         self.current_datetime += self.step_interval
+        self.boiler_upgrade_scheme_cumulative_spend_gbp += (
+            self.boiler_upgrade_scheme_spend_gbp
+        )
 
 
 def create_household_agents(

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -564,3 +564,24 @@ class TestHousehold:
             social_rented_household.get_heating_fuel_costs(heating_system, model) == 0
         )
         assert owned_household.get_heating_fuel_costs(heating_system, model) > 0
+
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_total_heating_system_costs_are_lower_for_heat_pumps_if_model_intervention_boiler_upgrade_scheme(
+        self, heat_pump
+    ):
+
+        household = household_factory(heating_system=random.choices(list(BOILERS))[0])
+
+        model_without_boiler_upgrade_scheme = model_factory(
+            start_datetime=datetime.datetime(2023, 1, 1, 0, 0)
+        )
+        model_with_boiler_upgrade_scheme = model_factory(
+            start_datetime=datetime.datetime(2023, 1, 1, 0, 0),
+            intervention="boiler_upgrade_scheme",
+        )
+
+        assert household.get_total_heating_system_costs(
+            heat_pump, model_with_boiler_upgrade_scheme
+        ) < household.get_total_heating_system_costs(
+            heat_pump, model_without_boiler_upgrade_scheme
+        )

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -177,10 +177,12 @@ class TestCosts:
             quote = future_quote
 
     @pytest.mark.parametrize("boiler", set(BOILERS))
-    def test_boiler_upgrade_scheme_grant_is_always_zero_for_boilers(self, boiler):
+    def test_boiler_upgrade_scheme_grant_is_zero_for_boilers_within_grant_window(
+        self, boiler
+    ):
 
-        start_datetime = datetime.datetime(2022, 1, 1, 0, 0)
-        end_datetime = datetime.datetime(2032, 1, 1, 0, 0)
+        start_datetime = datetime.datetime(2022, 4, 1, 0, 0)
+        end_datetime = datetime.datetime(2025, 4, 1, 0, 0)
         random_n_days = random.randrange((end_datetime - start_datetime).days)
         start_datetime = start_datetime + datetime.timedelta(days=random_n_days)
 
@@ -190,16 +192,13 @@ class TestCosts:
 
         assert estimate_boiler_upgrade_scheme_grant(boiler, model) == 0
 
-    @pytest.mark.parametrize("heat_pump", set(HEAT_PUMPS))
+    @pytest.mark.parametrize("heating_system", set(HeatingSystem))
     def test_boiler_upgrade_scheme_grant_is_zero_when_outside_grant_window(
-        self, heat_pump
+        self, heating_system
     ):
 
-        model = model_factory(start_datetime=datetime.datetime(2023, 1, 1, 0, 0))
-        assert estimate_boiler_upgrade_scheme_grant(heat_pump, model) > 0
-
-        model.current_datetime = datetime.datetime(2027, 1, 1, 0, 0)
-        assert estimate_boiler_upgrade_scheme_grant(heat_pump, model) == 0
+        model = model_factory(start_datetime=datetime.datetime(2026, 1, 1, 0, 0))
+        assert estimate_boiler_upgrade_scheme_grant(heating_system, model) == 0
 
     @pytest.mark.parametrize("heat_pump", set(HEAT_PUMPS))
     def test_boiler_upgrade_scheme_grant_is_zero_when_grant_cap_exceeded(

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -13,7 +13,7 @@ from simulation.constants import (
     PropertyType,
 )
 from simulation.model import create_household_agents
-from simulation.tests.common import model_factory
+from simulation.tests.common import household_factory, model_factory
 
 
 class TestDomesticHeatingABM:
@@ -27,6 +27,32 @@ class TestDomesticHeatingABM:
 
         model.increment_timestep()
         assert model.current_datetime == start_datetime + step_interval
+
+    def test_increment_timestep_updates_boiler_upgrade_scheme_cumulative_spend_gbp(
+        self,
+    ) -> None:
+
+        model = model_factory()
+        assert model.boiler_upgrade_scheme_cumulative_spend_gbp == 0
+
+        household_using_boiler_upgrade_grant_ASHP = household_factory()
+        household_using_boiler_upgrade_grant_ASHP.boiler_upgrade_grant_used = 5_000
+
+        household_using_boiler_upgrade_grant_GSHP = household_factory()
+        household_using_boiler_upgrade_grant_GSHP.boiler_upgrade_grant_used = 6_000
+
+        model.add_agents(
+            [
+                household_using_boiler_upgrade_grant_ASHP,
+                household_using_boiler_upgrade_grant_GSHP,
+            ]
+        )
+
+        model.increment_timestep()
+        assert model.boiler_upgrade_scheme_cumulative_spend_gbp == 11_000
+
+        model.increment_timestep()
+        assert model.boiler_upgrade_scheme_cumulative_spend_gbp == 22_000
 
 
 def test_create_household_agents() -> None:


### PR DESCRIPTION
- Adds `boiler_upgrade_scheme` as an intervention type, as per the details outlined [here](https://www.gov.uk/government/news/plan-to-drive-down-the-cost-of-clean-heat) and [here](https://www.homebuilding.co.uk/advice/boiler-upgrade-scheme).
- Over the calendar dates that the grant is active, households will be eligible for the grant when switching to a heat pump -- if the total model budget of £450mil is not exceeded. In practice, this cap is not likely to be enforced when modelling at a sub-UK level, but it is nonetheless of interest to track total uptake within a simulation. Additional logic is added to DomesticHeatingABM to sum and store the grants used by households, and collector is added to log this total value.
- New household attributes `boiler_upgrade_grant_available` and `boiler_upgrade_grant_used` store information about whether the grant was available to a household when making a heating decision, and whether or not they used the grant, respectively, to assist with total grant budget tracking and downstream analysis