### PR TITLE
Update model parameters and heating decision weights post-calibration with RHI uptake

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -53,7 +53,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--heating-system-hassle-factor",
         type=float_between_0_and_1,
-        default=0.3,
+        default=0.1,
         help="A value between 0 and 1 which suppresses the likelihood of a household choosing a given heating system (the higher the value, the lower the likelihood)",
     )
 

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -37,7 +37,7 @@ def parse_args(args=None):
 
     parser.add_argument("--steps", dest="time_steps", type=int, default=100)
     parser.add_argument("--heat-pump-awareness", type=float, default=0.4)
-    parser.add_argument("--annual-renovation-rate", type=float, default=0.05)
+    parser.add_argument("--annual-renovation-rate", type=float, default=0.1)
     parser.add_argument(
         "--household-num-lookahead-years",
         type=int,

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -473,6 +473,11 @@ class Household(Agent):
                 weight *= 1 - heating_system_hassle_factor
             weights.append(weight)
 
+        #  Households for which all options are highly unaffordable (x10 out of budget) "repair" their existing heating system
+        threshold_weight = 1 / (1 + math.exp(10))
+        if all([w < threshold_weight for w in weights]):
+            return self.heating_system
+
         return random.choices(list(costs.keys()), weights)[0]
 
     def install_heating_system(

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -468,13 +468,13 @@ class Household(Agent):
             cost_as_proportion_of_budget = min(
                 costs[heating_system] / self.renovation_budget, multiple_cap
             )
-            weight = 1 / (1 + math.exp(cost_as_proportion_of_budget))
+            weight = 1 / math.exp(cost_as_proportion_of_budget)
             if self.is_heating_system_hassle(heating_system):
                 weight *= 1 - heating_system_hassle_factor
             weights.append(weight)
 
         #  Households for which all options are highly unaffordable (x10 out of budget) "repair" their existing heating system
-        threshold_weight = 1 / (1 + math.exp(10))
+        threshold_weight = 1 / math.exp(10)
         if all([w < threshold_weight for w in weights]):
             return self.heating_system
 

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -177,8 +177,8 @@ RENO_PROBA_INSULATION_UPDATE = 0.33
 RENO_NUM_INSULATION_ELEMENTS_UPGRADED = {1: 0.76, 2: 0.17, 3: 0.07}
 
 # An amount a house may set aside for work related to home heating and energy efficiency
-# Expressed as a proportion of their total renovation budget (10%)
-HEATING_PROPORTION_OF_RENO_BUDGET = 0.1
+# Expressed as a proportion of their total renovation budget (20%)
+HEATING_PROPORTION_OF_RENO_BUDGET = 0.2
 
 # Upper bound on floor area sqm for to be classed as 'Small', by property type / built form
 # As per the segmentation used in Source: BEIS - WHAT DOES IT COST TO RETROFIT HOMES?


### PR DESCRIPTION
- This PR modifies a number of default parameters and the weights used when choosing between systems, as part of the process of reconciling the outputs of the ABM with historical heat pump uptake under the RHI. The changes to the latter mean that households weight heating system options with greater discrimination; previously the function weights 'plateaued' when a system was priced at ~40% of a household's budget or lower, while the updated function continues to weight heating systems more highly as they fall below 40% of the budget (i.e. households prefer a system which is 20% of their budget over a heating system which is 30% or 40% of their budget).
- As part of this calibration, it was also found that households who find all heating system options highly unaffordable approximately end up with the same "weight" or uniform likelihood of choosing from the heating systems available. This can lead to the unintuitive outcome that households with very low renovation budgets choose the most expensive options, like heat pumps.
- This therefore also includes a code change to ensure that households for which _all_ options are highly unaffordable (set at x10 out of budget) choose their existing heating system (which can be interpreted as a "repair")
