### PR TITLE
Update cl arg --intervention to pass multiple interventions to simulation

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -71,8 +71,8 @@ def parse_args(args=None):
     parser.add_argument(
         "--intervention",
         action="append",
-        help="Valid interventions are: " + ', '.join(member.name for member in InterventionType)
-'RHI, BOILER_UPGRADE_SCHEME',
+        help="Valid interventions are: "
+        + ", ".join(member.name for member in InterventionType),
         type=map_string_to_intervention_type_enum,
     )
 

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -21,11 +21,8 @@ def parse_args(args=None):
             return float(value)
         raise ValueError(f"Value must be between 0 and 1, got {value}")
 
-    def convert_str_to_intervention_list(intervention_string):
-        return [
-            InterventionType[intervention.upper()]
-            for intervention in intervention_string.split(",")
-        ]
+    def map_string_to_intervention_type_enum(intervention):
+        return InterventionType[intervention.upper()]
 
     parser = argparse.ArgumentParser()
 
@@ -73,9 +70,10 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "--interventions",
-        help="A comma separated list of interventions, without spaces. Valid list items are: rhi, boiler_upgrade_scheme.",
-        type=convert_str_to_intervention_list,
+        "--intervention",
+        action="append",
+        help="Valid interventions are: rhi, boiler_upgrade_scheme.",
+        type=map_string_to_intervention_type_enum,
     )
 
     parser.add_argument(
@@ -123,7 +121,7 @@ if __name__ == "__main__":
         args.annual_renovation_rate,
         args.household_num_lookahead_years,
         args.heating_system_hassle_factor,
-        args.interventions,
+        args.intervention,
         args.air_source_heat_pump_discount_factor_2022,
         args.all_agents_heat_pump_suitable,
     )

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -71,7 +71,8 @@ def parse_args(args=None):
     parser.add_argument(
         "--intervention",
         action="append",
-        help="Valid interventions are: rhi, boiler_upgrade_scheme.",
+        help="Valid interventions are: " + ', '.join(member.name for member in InterventionType)
+'RHI, BOILER_UPGRADE_SCHEME',
         type=map_string_to_intervention_type_enum,
     )
 

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -84,7 +84,7 @@ def parse_args(args=None):
         "--all-agents-heat-pump-suitable",
         default=False,
         type=bool,
-        help="When True, 100%% of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
+        help="When True, 100% of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
     )
 
     parser.add_argument(

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -5,6 +5,7 @@ import random
 import pandas as pd
 
 from abm import write_jsonlines
+from simulation.constants import InterventionType
 from simulation.model import create_and_run_simulation
 
 
@@ -14,6 +15,19 @@ def parse_args(args=None):
 
     def convert_to_timedelta(minutes_string):
         return datetime.timedelta(minutes=int(minutes_string))
+
+    def float_between_0_and_1(value: str):
+        if 0 <= float(value) <= 1:
+            return float(value)
+        raise ValueError(f"Value must be between 0 and 1, got {value}")
+
+    def convert_str_to_intervention_list(intervention_string):
+        if intervention_string:
+            return [
+                InterventionType[intervention.upper()]
+                for intervention in intervention_string.split(",")
+            ]
+        return []
 
     parser = argparse.ArgumentParser()
 
@@ -53,11 +67,6 @@ def parse_args(args=None):
         help="The number of years households look ahead when making purchasing decisions; any cash flows to be exchanged further than this number of years in the future are valued at £0 by households",
     )
 
-    def float_between_0_and_1(value: str):
-        if 0 <= float(value) <= 1:
-            return float(value)
-        raise ValueError(f"Value must be between 0 and 1, got {value}")
-
     parser.add_argument(
         "--heating-system-hassle-factor",
         type=float_between_0_and_1,
@@ -66,9 +75,9 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "--intervention",
-        choices=["rhi", "boiler_upgrade_scheme"],
-        type=str,
+        "--interventions",
+        help="A comma separated list of interventions, without spaces. Valid list items are: rhi, boiler_upgrade_scheme.",
+        type=convert_str_to_intervention_list,
     )
 
     parser.add_argument(
@@ -116,7 +125,7 @@ if __name__ == "__main__":
         args.annual_renovation_rate,
         args.household_num_lookahead_years,
         args.heating_system_hassle_factor,
-        args.intervention,
+        args.interventions,
         args.air_source_heat_pump_discount_factor_2022,
         args.all_agents_heat_pump_suitable,
     )

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -84,7 +84,7 @@ def parse_args(args=None):
         "--all-agents-heat-pump-suitable",
         default=False,
         type=bool,
-        help="When True, 100% of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
+        help="When True, 100pc of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
     )
 
     parser.add_argument(

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -22,12 +22,10 @@ def parse_args(args=None):
         raise ValueError(f"Value must be between 0 and 1, got {value}")
 
     def convert_str_to_intervention_list(intervention_string):
-        if intervention_string:
-            return [
-                InterventionType[intervention.upper()]
-                for intervention in intervention_string.split(",")
-            ]
-        return []
+        return [
+            InterventionType[intervention.upper()]
+            for intervention in intervention_string.split(",")
+        ]
 
     parser = argparse.ArgumentParser()
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -442,14 +442,14 @@ class Household(Agent):
             if subsidies > 0:
                 self.boiler_upgrade_grant_available = True
 
-        if InterventionType.RHI in model.interventions:
+        elif InterventionType.RHI in model.interventions:
             rhi_annual_payment = estimate_rhi_annual_payment(self, heating_system)
             subsidies = discount_annual_cash_flow(
                 discount_rate=self.discount_rate,
                 cashflow_gbp=rhi_annual_payment,
                 duration_years=7,
             )
-        if not model.interventions:
+        else:
             subsidies = 0
 
         return unit_and_install_costs, fuel_costs_net_present_value, -subsidies

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -437,19 +437,19 @@ class Household(Agent):
             heating_system, model
         )
 
-        if model.intervention == InterventionType.BOILER_UPGRADE_SCHEME:
+        if InterventionType.BOILER_UPGRADE_SCHEME in model.interventions:
             subsidies = estimate_boiler_upgrade_scheme_grant(heating_system, model)
             if subsidies > 0:
                 self.boiler_upgrade_grant_available = True
 
-        if model.intervention == InterventionType.RHI:
+        if InterventionType.RHI in model.interventions:
             rhi_annual_payment = estimate_rhi_annual_payment(self, heating_system)
             subsidies = discount_annual_cash_flow(
                 discount_rate=self.discount_rate,
                 cashflow_gbp=rhi_annual_payment,
                 duration_years=7,
             )
-        if not model.intervention:
+        if not model.interventions:
             subsidies = 0
 
         return unit_and_install_costs, fuel_costs_net_present_value, -subsidies

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 
 import pandas as pd
 
@@ -121,7 +121,7 @@ def create_and_run_simulation(
     annual_renovation_rate: float,
     household_num_lookahead_years: int,
     heating_system_hassle_factor: float,
-    interventions: List[InterventionType],
+    interventions: Optional[List[InterventionType]],
     air_source_heat_pump_discount_factor_2022: float,
     all_agents_heat_pump_suitable: bool,
 ):

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -37,7 +37,7 @@ class DomesticHeatingABM(AgentBasedModel):
         self.heating_systems = set(HeatingSystem)
         self.household_num_lookahead_years = household_num_lookahead_years
         self.heating_system_hassle_factor = heating_system_hassle_factor
-        self.interventions = interventions
+        self.interventions = interventions or []
         self.air_source_heat_pump_discount_factor_2022 = (
             air_source_heat_pump_discount_factor_2022
         )

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from typing import Iterator
+from typing import Iterator, List
 
 import pandas as pd
 
@@ -27,7 +27,7 @@ class DomesticHeatingABM(AgentBasedModel):
         annual_renovation_rate,
         household_num_lookahead_years,
         heating_system_hassle_factor,
-        intervention,
+        interventions,
         air_source_heat_pump_discount_factor_2022,
     ):
         self.start_datetime = start_datetime
@@ -37,9 +37,7 @@ class DomesticHeatingABM(AgentBasedModel):
         self.heating_systems = set(HeatingSystem)
         self.household_num_lookahead_years = household_num_lookahead_years
         self.heating_system_hassle_factor = heating_system_hassle_factor
-        self.intervention = (
-            InterventionType[intervention.upper()] if intervention else None
-        )
+        self.interventions = interventions
         self.air_source_heat_pump_discount_factor_2022 = (
             air_source_heat_pump_discount_factor_2022
         )
@@ -123,7 +121,7 @@ def create_and_run_simulation(
     annual_renovation_rate: float,
     household_num_lookahead_years: int,
     heating_system_hassle_factor: float,
-    intervention: str,
+    interventions: List[InterventionType],
     air_source_heat_pump_discount_factor_2022: float,
     all_agents_heat_pump_suitable: bool,
 ):
@@ -134,7 +132,7 @@ def create_and_run_simulation(
         annual_renovation_rate=annual_renovation_rate,
         household_num_lookahead_years=household_num_lookahead_years,
         heating_system_hassle_factor=heating_system_hassle_factor,
-        intervention=intervention,
+        interventions=interventions,
         air_source_heat_pump_discount_factor_2022=air_source_heat_pump_discount_factor_2022,
     )
 

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -22,13 +22,13 @@ from simulation.constants import (
 class DomesticHeatingABM(AgentBasedModel):
     def __init__(
         self,
-        start_datetime,
-        step_interval,
-        annual_renovation_rate,
-        household_num_lookahead_years,
-        heating_system_hassle_factor,
-        interventions,
-        air_source_heat_pump_discount_factor_2022,
+        start_datetime: datetime.datetime,
+        step_interval: int,
+        annual_renovation_rate: float,
+        household_num_lookahead_years: int,
+        heating_system_hassle_factor: float,
+        interventions: Optional[List[InterventionType]],
+        air_source_heat_pump_discount_factor_2022: float,
     ):
         self.start_datetime = start_datetime
         self.step_interval = step_interval

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -44,7 +44,7 @@ def model_factory(**model_attributes):
         "annual_renovation_rate": 0.05,
         "household_num_lookahead_years": 3,
         "heating_system_hassle_factor": 0.7,
-        "intervention": None,
+        "interventions": [],
         "air_source_heat_pump_discount_factor_2022": 0,
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -16,6 +16,7 @@ from simulation.constants import (
     EventTrigger,
     HeatingFuel,
     HeatingSystem,
+    InterventionType,
     OccupantType,
     PropertySize,
     PropertyType,
@@ -533,7 +534,7 @@ class TestHousehold:
         household = household_factory(heating_system=random.choices(list(BOILERS))[0])
 
         model_without_rhi = model_factory()
-        model_with_rhi = model_factory(intervention="rhi")
+        model_with_rhi = model_factory(interventions=[InterventionType.RHI])
 
         assert sum(
             household.get_total_heating_system_costs(heat_pump, model_with_rhi)
@@ -577,7 +578,7 @@ class TestHousehold:
         )
         model_with_boiler_upgrade_scheme = model_factory(
             start_datetime=datetime.datetime(2023, 1, 1, 0, 0),
-            intervention="boiler_upgrade_scheme",
+            interventions=[InterventionType.BOILER_UPGRADE_SCHEME],
         )
 
         assert sum(

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -9,6 +9,7 @@ import pytest
 import simulation.__main__
 from abm import read_jsonlines
 from simulation.__main__ import parse_args
+from simulation.constants import InterventionType
 
 
 @pytest.fixture
@@ -109,6 +110,22 @@ class TestParseArgs:
     def test_no_household_input_fails(self, output_file):
         with pytest.raises(SystemExit):
             parse_args([output_file])
+
+    def test_intervention_argument(self, mandatory_local_args):
+        args = parse_args(
+            [
+                *mandatory_local_args,
+                "--intervention",
+                "rhi",
+                "--intervention",
+                "boiler_upgrade_scheme",
+            ]
+        )
+
+        assert args.intervention == [
+            InterventionType.RHI,
+            InterventionType.BOILER_UPGRADE_SCHEME,
+        ]
 
 
 def assert_histories_equal(first_history, second_history):


### PR DESCRIPTION
- Update `--intervention` arg to enable multi-intervention simulations in the future, such as Boiler Upgrade Scheme + Boiler Ban
- As not all interventions we plan to implement will result in a subsidy seen by households (e.g. boiler ban), the logic used in `household.get_total_heating_system_costs()` is amended to anticipate this (previously, a £0 subsidy would only be assigned if model intervention attribute was empty)