### PR TITLE
Add intervention - gas and oil boiler ban

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -108,7 +108,7 @@ def parse_args(args=None):
 
     parser.add_argument(
         "--gas-oil-boiler-ban-date",
-        default=datetime.datetime(2035, 1, 1, 0, 0),
+        default=datetime.datetime(2035, 1, 1),
         type=convert_to_datetime,
     )
 

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -104,6 +104,12 @@ def parse_args(args=None):
         metavar="YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]]",
     )
 
+    parser.add_argument(
+        "--gas-oil-boiler-ban-date",
+        default=datetime.datetime(2035, 1, 1, 0, 0),
+        type=convert_to_datetime,
+    )
+
     return parser.parse_args(args)
 
 
@@ -123,6 +129,7 @@ if __name__ == "__main__":
         args.intervention,
         args.air_source_heat_pump_discount_factor_2022,
         args.all_agents_heat_pump_suitable,
+        args.gas_oil_boiler_ban_date,
     )
 
     write_jsonlines(history, args.history_file)

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -198,3 +198,4 @@ FLOOR_AREA_SQM_66TH_PERCENTILE = 89
 class InterventionType(enum.Enum):
     RHI = 0
     BOILER_UPGRADE_SCHEME = 1
+    GAS_OIL_BOILER_BAN = 2

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -46,5 +46,6 @@ def model_factory(**model_attributes):
         "heating_system_hassle_factor": 0.7,
         "interventions": [],
         "air_source_heat_pump_discount_factor_2022": 0,
+        "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1, 0, 0),
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -46,6 +46,6 @@ def model_factory(**model_attributes):
         "heating_system_hassle_factor": 0.7,
         "interventions": [],
         "air_source_heat_pump_discount_factor_2022": 0,
-        "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1, 0, 0),
+        "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1),
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -599,9 +599,9 @@ class TestHousehold:
         household = household_factory(heating_system=random.choices(list(BOILERS))[0])
 
         model_with_gas_oil_boiler_ban = model_factory(
-            start_datetime=datetime.datetime(2035, 3, 1, 0, 0),
+            start_datetime=datetime.datetime(2035, 3, 1),
             interventions=[InterventionType.GAS_OIL_BOILER_BAN],
-            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1, 0, 0),
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
         )
 
         banned_heating_systems = [HeatingSystem.BOILER_GAS, HeatingSystem.BOILER_OIL]

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -590,3 +590,26 @@ class TestHousehold:
                 heat_pump, model_without_boiler_upgrade_scheme
             )
         )
+
+    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    def test_gas_and_oil_boilers_are_not_in_heating_options_if_gas_oil_ban_intervention_active(
+        self, event_trigger
+    ):
+
+        household = household_factory(heating_system=random.choices(list(BOILERS))[0])
+
+        model_with_gas_oil_boiler_ban = model_factory(
+            start_datetime=datetime.datetime(2035, 3, 1, 0, 0),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1, 0, 0),
+        )
+
+        banned_heating_systems = [HeatingSystem.BOILER_GAS, HeatingSystem.BOILER_OIL]
+        heating_system_options = household.get_heating_system_options(
+            model_with_gas_oil_boiler_ban, event_trigger=event_trigger
+        )
+
+        assert all(
+            heating_system not in heating_system_options
+            for heating_system in banned_heating_systems
+        )

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -133,6 +133,12 @@ class TestParseArgs:
             InterventionType.BOILER_UPGRADE_SCHEME,
         ]
 
+    def test_gas_oil_boiler_ban_date_returns_datetime(self, mandatory_local_args):
+        args = parse_args(
+            [*mandatory_local_args, "--gas-oil-boiler-ban-date", "2030-01-01"]
+        )
+        assert args.gas_oil_boiler_ban_date == datetime.datetime(2030, 1, 1)
+
 
 def assert_histories_equal(first_history, second_history):
     first_agent_history, first_model_history = first_history


### PR DESCRIPTION
- Adds gas and oil boiler ban, as of the `--gas-oil-boiler-ban-date` cl arg (default: 2035-01-01)
- Instead of being a static attribute set at model initialisation, the set of heating systems available is revised into a model property, which gets re-evaluated (based upon the model interventions list, boiler ban date and current model datetime) whenever households make heating decisions
- Note that post-ban, some households can have no heating systems available to them -- e.g. due to unsuitability for heat pumps or electric boilers, and/or because the replacement is triggered by `EventTrigger.BREAKDOWN`, in which heat pumps are not available due to the high lead times required. As for the case where households find all heating system options highly unaffordable, the fallback behaviour here is for a household to select their current heating system, which can be interpreted as repairing their heating system or violating a ban in the absence of a viable alternative. This behaviour can be reviewed further separately of this PR.