### PR TITLE
Households aware of heat pumps and consider them in breakdowns if boiler ban active

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -140,7 +140,7 @@ class Household(Agent):
         self.walls_energy_efficiency = walls_energy_efficiency
         self.roof_energy_efficiency = roof_energy_efficiency
         self.windows_energy_efficiency = windows_energy_efficiency
-        self.is_heat_pump_aware_init = is_heat_pump_aware
+        self.is_heat_pump_aware = is_heat_pump_aware
 
         # Household investment decision attributes
         self.is_renovating = False
@@ -269,16 +269,6 @@ class Household(Agent):
             * HEATING_FUEL_PRICE_GBP_PER_KWH[HEATING_SYSTEM_FUEL[self.heating_system]]
         )
 
-    def is_heat_pump_aware(self, model: "DomesticHeatingABM") -> bool:
-
-        # all households will be aware of heat pumps once a gas/oil boiler ban is active
-        if (
-            InterventionType.GAS_OIL_BOILER_BAN in model.interventions
-            and model.current_datetime > model.gas_oil_boiler_ban_datetime
-        ):
-            return True
-        return self.is_heat_pump_aware_init
-
     def heating_system_age_years(self, current_date: datetime.date) -> float:
         return (current_date - self.heating_system_install_date).days / 365
 
@@ -403,8 +393,19 @@ class Household(Agent):
     ) -> Set[HeatingSystem]:
 
         heating_system_options = model.heating_systems.copy()
-        if not self.is_heat_pump_suitable or not self.is_heat_pump_aware(model):
+
+        is_gas_oil_boiler_ban_active = (
+            InterventionType.GAS_OIL_BOILER_BAN in model.interventions
+            and model.current_datetime >= model.gas_oil_boiler_ban_datetime
+        )
+
+        if not self.is_heat_pump_suitable:
             heating_system_options -= HEAT_PUMPS
+
+        if not is_gas_oil_boiler_ban_active:
+            # if a gas/boiler ban is active, we assume all households are aware of heat pumps
+            if not self.is_heat_pump_aware:
+                heating_system_options -= HEAT_PUMPS
 
         if self.is_off_gas_grid:
             heating_system_options -= {HeatingSystem.BOILER_GAS}
@@ -416,10 +417,7 @@ class Household(Agent):
 
         # heat pumps are unfeasible in a breakdown due to installation lead times
         # exceptions: household already has a heat pump, or a gas/oil boiler ban is active
-        if (
-            event_trigger == EventTrigger.BREAKDOWN
-            and InterventionType.GAS_OIL_BOILER_BAN not in model.interventions
-        ):
+        if event_trigger == EventTrigger.BREAKDOWN and not is_gas_oil_boiler_ban_active:
             unfeasible_heating_systems = HEAT_PUMPS - {self.heating_system}
             heating_system_options -= unfeasible_heating_systems
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -140,7 +140,7 @@ class Household(Agent):
         self.walls_energy_efficiency = walls_energy_efficiency
         self.roof_energy_efficiency = roof_energy_efficiency
         self.windows_energy_efficiency = windows_energy_efficiency
-        self.is_heat_pump_aware = is_heat_pump_aware
+        self.is_heat_pump_aware_init = is_heat_pump_aware
 
         # Household investment decision attributes
         self.is_renovating = False
@@ -269,6 +269,16 @@ class Household(Agent):
             * HEATING_FUEL_PRICE_GBP_PER_KWH[HEATING_SYSTEM_FUEL[self.heating_system]]
         )
 
+    def is_heat_pump_aware(self, model: "DomesticHeatingABM") -> bool:
+
+        # all households will be aware of heat pumps once a gas/oil boiler ban is active
+        if (
+            InterventionType.GAS_OIL_BOILER_BAN in model.interventions
+            and model.current_datetime > model.gas_oil_boiler_ban_datetime
+        ):
+            return True
+        return self.is_heat_pump_aware_init
+
     def heating_system_age_years(self, current_date: datetime.date) -> float:
         return (current_date - self.heating_system_install_date).days / 365
 
@@ -393,7 +403,7 @@ class Household(Agent):
     ) -> Set[HeatingSystem]:
 
         heating_system_options = model.heating_systems.copy()
-        if not self.is_heat_pump_suitable or not self.is_heat_pump_aware:
+        if not self.is_heat_pump_suitable or not self.is_heat_pump_aware(model):
             heating_system_options -= HEAT_PUMPS
 
         if self.is_off_gas_grid:
@@ -404,9 +414,12 @@ class Household(Agent):
         if self.property_size != PropertySize.SMALL:
             heating_system_options -= {HeatingSystem.BOILER_ELECTRIC}
 
-        if event_trigger == EventTrigger.BREAKDOWN:
-            # if household already has a heat pump, they can reinstall that type of heat pump in a breakdown
-            # heat pumps are otherwise unfeasible in a breakdown due to installation lead times
+        # heat pumps are unfeasible in a breakdown due to installation lead times
+        # exceptions: household already has a heat pump, or a gas/oil boiler ban is active
+        if (
+            event_trigger == EventTrigger.BREAKDOWN
+            and InterventionType.GAS_OIL_BOILER_BAN not in model.interventions
+        ):
             unfeasible_heating_systems = HEAT_PUMPS - {self.heating_system}
             heating_system_options -= unfeasible_heating_systems
 

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -93,8 +93,8 @@ def household_is_heat_pump_suitable_archetype(household) -> bool:
     return household.is_heat_pump_suitable_archetype
 
 
-def household_is_heat_pump_aware(household) -> bool:
-    return household.is_heat_pump_aware
+def household_is_heat_pump_aware_init(household) -> bool:
+    return household.is_heat_pump_aware_init
 
 
 def household_is_renovating(household) -> bool:
@@ -283,7 +283,7 @@ def get_agent_collectors(
         collect_when(model, is_first_timestep)(household_discount_rate),
         collect_when(model, is_first_timestep)(household_renovation_budget),
         collect_when(model, is_first_timestep)(household_is_heat_pump_suitable),
-        collect_when(model, is_first_timestep)(household_is_heat_pump_aware),
+        collect_when(model, is_first_timestep)(household_is_heat_pump_aware_init),
         household_heating_system,
         household_heating_system_previous,
         household_heating_functioning,

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -93,8 +93,8 @@ def household_is_heat_pump_suitable_archetype(household) -> bool:
     return household.is_heat_pump_suitable_archetype
 
 
-def household_is_heat_pump_aware_init(household) -> bool:
-    return household.is_heat_pump_aware_init
+def household_is_heat_pump_aware(household) -> bool:
+    return household.is_heat_pump_aware
 
 
 def household_is_renovating(household) -> bool:
@@ -283,7 +283,7 @@ def get_agent_collectors(
         collect_when(model, is_first_timestep)(household_discount_rate),
         collect_when(model, is_first_timestep)(household_renovation_budget),
         collect_when(model, is_first_timestep)(household_is_heat_pump_suitable),
-        collect_when(model, is_first_timestep)(household_is_heat_pump_aware_init),
+        collect_when(model, is_first_timestep)(household_is_heat_pump_aware),
         household_heating_system,
         household_heating_system_previous,
         household_heating_functioning,

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -613,3 +613,19 @@ class TestHousehold:
             heating_system not in heating_system_options
             for heating_system in banned_heating_systems
         )
+
+    def test_households_are_aware_of_heat_pumps_if_gas_oil_ban_intervention_active(self):
+
+        household = household_factory(heating_system=random.choices(list(BOILERS))[0],
+                                      is_heat_pump_aware=False)
+
+        model = model_factory()
+        assert not household.is_heat_pump_aware(model)
+
+        model_with_gas_oil_boiler_ban = model_factory(
+            start_datetime=datetime.datetime(2035, 3, 1),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
+        )
+
+        assert household.is_heat_pump_aware(model_with_gas_oil_boiler_ban)

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -615,13 +615,16 @@ class TestHousehold:
         )
 
     @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    @pytest.mark.parametrize("is_heat_pump_aware", [True, False])
     def test_heat_pump_suitable_households_can_choose_heat_pumps_in_all_event_triggers_and_irrespective_of_awareness_if_gas_oil_ban_intervention_active(
-        self, event_trigger
+        self,
+        event_trigger,
+        is_heat_pump_aware,
     ):
 
         household = household_factory(
             heating_system=random.choices(list(BOILERS))[0],
-            is_heat_pump_aware=random.choices([True, False])[0],
+            is_heat_pump_aware=is_heat_pump_aware,
             is_heat_pump_suitable_archetype=True,
         )
 


### PR DESCRIPTION
- Modifies `household.get_heating_system_options()` such that when a gas/boiler ban is active, all (heat pump suitable) households will consider heat pumps -- regardless of the `EventType`, and regardless of their `is_heat_pump_aware` attribute set at household init.