### PR TITLE
Write pickle to try and identify cause of flaky test

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ flake8 = "*"
 isort = "*"
 mypy = "*"
 pandas-stubs = "*"
+pytest-check = "==1.0.4"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "19dde94a6679811f7633d80a830200fa52324cd3af28ac322eef1eafbb5120ab"
+            "sha256": "745f6a68f9afdd48a5aa186480ce93ae2dcc66fcc7d6b07f31a9322ee2c2c96b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -87,11 +87,11 @@
         },
         "google-cloud-core": {
             "hashes": [
-                "sha256:476d1f71ab78089e0638e0aaf34bfdc99bab4fce8f4170ba6321a5243d13c5c7",
-                "sha256:ab6cee07791afe4e210807ceeab749da6a076ab16d496ac734bf7e6ffea27486"
+                "sha256:7d19bf8868b410d0bdf5a03468a3f3f2db233c0ee86a023f4ecc2b7a4b15f736",
+                "sha256:d9cffaf86df6a876438d4e8471183bbe404c9a15de9afe60433bc7dce8cb4252"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.2.1"
+            "version": "==2.2.2"
         },
         "google-cloud-storage": {
             "hashes": [
@@ -710,11 +710,11 @@
         },
         "pandas-stubs": {
             "hashes": [
-                "sha256:3e3c2fee7ebafe4fa9b9e37b60e6af5585c28c9a476f2f9768189e0ebbf63727",
-                "sha256:4459c63aba7289e959879c2ac16bf781e90b7d778c848843d8a4d6bddbd90d67"
+                "sha256:0c47c213ab92a8608376eee00efd207e7f7af0a7b44342a6dbaf61a6b21bcc0d",
+                "sha256:75c153b06b87bdb663908d1dc382abeb898e0e777c165cbb620df839a609370e"
             ],
             "index": "pypi",
-            "version": "==1.2.0.42"
+            "version": "==1.2.0.43"
         },
         "pathspec": {
             "hashes": [
@@ -778,6 +778,14 @@
             ],
             "index": "pypi",
             "version": "==7.0.0rc1"
+        },
+        "pytest-check": {
+            "hashes": [
+                "sha256:aacc9500178611f8ad075a7c46ce8de8ac34f05270eee28f223fb0c8622fbfbe",
+                "sha256:c93eee5a98bcd28634a4ec657ab62c46d25fa384300811e5a925d9c4d98b9540"
+            ],
+            "index": "pypi",
+            "version": "==1.0.4"
         },
         "tomli": {
             "hashes": [

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import datetime
 import os
+import pickle
 import random
 import uuid
 from functools import partial
@@ -143,8 +144,10 @@ if __name__ == "__main__":
         args.gas_oil_boiler_ban_date,
     )
 
-    if args.history_file.startswith("gs://"):
-        history = list(history)
+    history = list(history)
+
+    with open(args.history_file + ".pkl", "wb") as file:
+        pickle.dump(history, file)
 
     with smart_open.open(args.history_file, "w") as file:
         write_jsonlines(history, file)

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 
 import pandas as pd
 import pytest
+import pytest_check as check
 
 import simulation.__main__
 from abm import read_jsonlines
@@ -194,37 +195,20 @@ def test_running_simulation_twice_with_same_seed_gives_identical_results(
 
     subprocess.run(args, check=True)
     with open(history_file, "r") as file:
-        first_history = list(read_jsonlines(file))
+        first_history_json = list(read_jsonlines(file))
+
+    with open(history_file + ".pkl", "rb") as file:
+        first_history_pickle = pickle.load(file)
 
     subprocess.run(args, check=True)
     with open(history_file, "r") as file:
-        second_history = list(read_jsonlines(file))
+        second_history_json = list(read_jsonlines(file))
 
-    assert first_history == second_history
-
-
-def test_running_simulation_twice_with_same_seed_gives_identical_results_with_pickle(
-    mandatory_local_args,
-):
-    args = [
-        "python",
-        "-m",
-        "simulation",
-        *mandatory_local_args,
-        "--seed",
-        "2021-01-01",
-    ]
-    history_file = mandatory_local_args[1]
-
-    subprocess.run(args, check=True)
     with open(history_file + ".pkl", "rb") as file:
-        first_history = pickle.load(file)
+        second_history_pickle = pickle.load(file)
 
-    subprocess.run(args, check=True)
-    with open(history_file + ".pkl", "rb") as file:
-        second_history = pickle.load(file)
-
-    assert first_history == second_history
+    check.equal(first_history_json, second_history_json)
+    check.equal(first_history_pickle, second_history_pickle)
 
 
 def test_python_hash_randomization_is_disabled():

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import pickle
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock
@@ -198,6 +199,30 @@ def test_running_simulation_twice_with_same_seed_gives_identical_results(
     subprocess.run(args, check=True)
     with open(history_file, "r") as file:
         second_history = list(read_jsonlines(file))
+
+    assert first_history == second_history
+
+
+def test_running_simulation_twice_with_same_seed_gives_identical_results_with_pickle(
+    mandatory_local_args,
+):
+    args = [
+        "python",
+        "-m",
+        "simulation",
+        *mandatory_local_args,
+        "--seed",
+        "2021-01-01",
+    ]
+    history_file = mandatory_local_args[1]
+
+    subprocess.run(args, check=True)
+    with open(history_file + ".pkl", "rb") as file:
+        first_history = pickle.load(file)
+
+    subprocess.run(args, check=True)
+    with open(history_file + ".pkl", "rb") as file:
+        second_history = pickle.load(file)
 
     assert first_history == second_history
 


### PR DESCRIPTION
Compare pickle and JSON output in the same test. If they both fail, then we know it's a problem with the ABM class. If only the JSON fails, but the pickle doesn't, then we know it's a problem with the JSON (de)serialization. If the pickle fails but the JSON doesn't, well, I'm not sure what that means. Let's hope that doesn't happen!