### PR TITLE
Air source heat pump costs change according to specified date schedule

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -129,7 +129,8 @@ def parse_args(args=None):
         "--air-source-heat-pump-price-discount-date",
         action="append",
         type=map_string_to_datetime_float_tuple,
-        help="A factor by which heat pump prices will fall by a specified date, provided in format 'YYYY-MM-DD:price_discount' (e.g. '2023-01-01:0.3')",
+        help="A factor by which heat pump prices will fall by a specified date.",
+        metavar="YYYY-MM-DD:price_discount",
     )
 
     return parser.parse_args(args)

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -28,6 +28,10 @@ def parse_args(args=None):
     def map_string_to_intervention_type_enum(intervention):
         return InterventionType[intervention.upper()]
 
+    def map_string_to_datetime_float_tuple(date_price_discount_string):
+        date, price_discount = date_price_discount_string.split(":")
+        return datetime.datetime.strptime(date, "%Y-%m-%d"), float(price_discount)
+
     parser = argparse.ArgumentParser()
 
     households = parser.add_mutually_exclusive_group(required=True)
@@ -121,6 +125,13 @@ def parse_args(args=None):
         type=convert_to_datetime,
     )
 
+    parser.add_argument(
+        "--heat-pump-price-discount-date",
+        action="append",
+        type=map_string_to_datetime_float_tuple,
+        help="A factor by which heat pump prices will fall by a specified date, provided in format 'YYYY-MM-DD:price_discount' (e.g. '2023-01-01:0.3')",
+    )
+
     return parser.parse_args(args)
 
 
@@ -141,6 +152,7 @@ if __name__ == "__main__":
         args.air_source_heat_pump_discount_factor_2022,
         args.all_agents_heat_pump_suitable,
         args.gas_oil_boiler_ban_date,
+        args.heat_pump_price_discount_date,
     )
 
     if args.history_file.startswith("gs://"):

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -98,13 +98,6 @@ def parse_args(args=None):
         help="When True, 100pc of households are assumed suitable for heat pumps. When False, households are assigned a heat pump suitability as per the source data file.",
     )
 
-    parser.add_argument(
-        "--air-source-heat-pump-discount-factor-2022",
-        type=float,
-        default=0.1,
-        help="A factor by which current (2021) air source heat pump unit+install costs will have declined by, as of the end of 2022",
-    )
-
     def check_string_is_isoformat_datetime(string) -> str:
         datetime.datetime.fromisoformat(string)
         return string
@@ -126,7 +119,7 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "--heat-pump-price-discount-date",
+        "--air-source-heat-pump-price-discount-date",
         action="append",
         type=map_string_to_datetime_float_tuple,
         help="A factor by which heat pump prices will fall by a specified date, provided in format 'YYYY-MM-DD:price_discount' (e.g. '2023-01-01:0.3')",
@@ -149,10 +142,9 @@ if __name__ == "__main__":
         args.household_num_lookahead_years,
         args.heating_system_hassle_factor,
         args.intervention,
-        args.air_source_heat_pump_discount_factor_2022,
         args.all_agents_heat_pump_suitable,
         args.gas_oil_boiler_ban_date,
-        args.heat_pump_price_discount_date,
+        args.air_source_heat_pump_price_discount_date,
     )
 
     if args.history_file.startswith("gs://"):

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -175,9 +175,8 @@ def get_unit_and_install_costs(
 
     if heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
         kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)
-        unit_and_install_costs = (
-            MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity]
-            * model.air_source_heat_pump_discount_factor
+        unit_and_install_costs = MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity] * (
+            1 - model.air_source_heat_pump_discount_factor
         )
 
         if household.heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -1,5 +1,6 @@
 import datetime
 import random
+from bisect import bisect
 from typing import Iterator, List, Optional, Set, Tuple
 
 import pandas as pd
@@ -66,17 +67,15 @@ class DomesticHeatingABM(AgentBasedModel):
 
         dates = list(self.air_source_heat_pump_price_discount_schedule.keys())
         factors = list(self.air_source_heat_pump_price_discount_schedule.values())
-        date_ranges = list(zip(dates, dates[1:]))
+        index = bisect(dates, self.current_datetime)
 
-        for idx, date_range in enumerate(date_ranges):
-            if date_range[idx] <= self.current_datetime <= date_range[idx + 1]:
-                proportion_through_range = (self.current_datetime - date_range[0]) / (
-                    date_range[1] - date_range[0]
-                )
-                return (
-                    factors[idx]
-                    + (factors[idx + 1] - factors[idx]) * proportion_through_range
-                )
+        proportion_through_range = (self.current_datetime - dates[index - 1]) / (
+            dates[index] - dates[index - 1]
+        )
+        return (
+            factors[index - 1]
+            + (factors[index] - factors[index - 1]) * proportion_through_range
+        )
 
     @property
     def boiler_upgrade_scheme_spend_gbp(self) -> int:

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -75,16 +75,16 @@ class DomesticHeatingABM(AgentBasedModel):
     @property
     def air_source_heat_pump_discount_factor(self) -> float:
 
-        dates = list(self.air_source_heat_pump_price_discount_schedule.keys())
+        dates = list(self.air_source_heat_pump_price_discount_schedule)
         factors = list(self.air_source_heat_pump_price_discount_schedule.values())
         index = bisect(dates, self.current_datetime)
 
-        proportion_through_range = (self.current_datetime - dates[index - 1]) / (
+        proportion_through_date_range = (self.current_datetime - dates[index - 1]) / (
             dates[index] - dates[index - 1]
         )
         return (
             factors[index - 1]
-            + (factors[index] - factors[index - 1]) * proportion_through_range
+            + (factors[index] - factors[index - 1]) * proportion_through_date_range
         )
 
     @property
@@ -113,12 +113,9 @@ class DomesticHeatingABM(AgentBasedModel):
         if heat_pump_price_discount_schedule:
 
             discount_schedule = {
-                schedule[0]: schedule[1]
-                for schedule in heat_pump_price_discount_schedule
+                date: discount for date, discount in heat_pump_price_discount_schedule
             }
-
-            price_change_dates = discount_schedule.keys()
-            first_date, last_date = min(price_change_dates), max(price_change_dates)
+            first_date, last_date = min(discount_schedule), max(discount_schedule)
 
             if first_date > self.start_datetime:
                 discount_schedule[self.start_datetime] = 0

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -75,6 +75,23 @@ class DomesticHeatingABM(AgentBasedModel):
             return 1 - (month / 12 * self.air_source_heat_pump_discount_factor_2022)
 
     @property
+    def heat_pump_discount_factor(self) -> float:
+
+        dates = list(self.heat_pump_price_discount_schedule.keys())
+        factors = list(self.heat_pump_price_discount_schedule.values())
+        date_ranges = list(zip(dates, dates[1:]))
+
+        for idx, date_range in enumerate(date_ranges):
+            if date_range[idx] <= self.current_datetime <= date_range[idx+1]:
+                proportion_through_range = (self.current_datetime - date_range[0]) / (
+                    date_range[1] - date_range[0]
+                )
+                return (
+                    factors[idx]
+                    + (factors[idx + 1] - factors[idx]) * proportion_through_range
+                )
+
+    @property
     def boiler_upgrade_scheme_spend_gbp(self) -> int:
         return sum(
             [

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from bisect import bisect
+from bisect import bisect_left
 from typing import Iterator, List, Optional, Set, Tuple
 
 import pandas as pd
@@ -77,7 +77,7 @@ class DomesticHeatingABM(AgentBasedModel):
 
         dates = list(self.air_source_heat_pump_price_discount_schedule)
         factors = list(self.air_source_heat_pump_price_discount_schedule.values())
-        index = bisect(dates, self.current_datetime)
+        index = bisect_left(dates, self.current_datetime)
 
         proportion_through_date_range = (self.current_datetime - dates[index - 1]) / (
             dates[index] - dates[index - 1]

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -1,6 +1,6 @@
 import datetime
 import random
-from typing import Iterator, List, Optional, Set
+from typing import Iterator, List, Optional, Set, Tuple
 
 import pandas as pd
 
@@ -30,6 +30,7 @@ class DomesticHeatingABM(AgentBasedModel):
         interventions: Optional[List[InterventionType]],
         air_source_heat_pump_discount_factor_2022: float,
         gas_oil_boiler_ban_datetime: datetime.datetime,
+        heat_pump_price_discount_schedule: List[Tuple[datetime.datetime, float]],
     ):
         self.start_datetime = start_datetime
         self.step_interval = step_interval
@@ -43,7 +44,7 @@ class DomesticHeatingABM(AgentBasedModel):
         )
         self.boiler_upgrade_scheme_cumulative_spend_gbp = 0
         self.gas_oil_boiler_ban_datetime = gas_oil_boiler_ban_datetime
-
+        self.heat_pump_price_discount_schedule = heat_pump_price_discount_schedule
         super().__init__(UnorderedSpace())
 
     @property
@@ -136,6 +137,7 @@ def create_and_run_simulation(
     air_source_heat_pump_discount_factor_2022: float,
     all_agents_heat_pump_suitable: bool,
     gas_oil_boiler_ban_datetime: datetime.datetime,
+    heat_pump_price_discount_schedule: List[Tuple[datetime.datetime, float]],
 ):
 
     model = DomesticHeatingABM(
@@ -147,6 +149,7 @@ def create_and_run_simulation(
         interventions=interventions,
         air_source_heat_pump_discount_factor_2022=air_source_heat_pump_discount_factor_2022,
         gas_oil_boiler_ban_datetime=gas_oil_boiler_ban_datetime,
+        heat_pump_price_discount_schedule=heat_pump_price_discount_schedule,
     )
 
     households = create_household_agents(

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -41,6 +41,7 @@ def model_factory(**model_attributes):
     default_values = {
         "start_datetime": datetime.datetime.now(),
         "step_interval": datetime.timedelta(minutes=1440),
+        "end_datetime": datetime.datetime(2035, 1, 1),
         "annual_renovation_rate": 0.05,
         "household_num_lookahead_years": 3,
         "heating_system_hassle_factor": 0.7,

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -47,5 +47,6 @@ def model_factory(**model_attributes):
         "interventions": [],
         "air_source_heat_pump_discount_factor_2022": 0,
         "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1),
+        "heat_pump_price_discount_schedule": [(datetime.datetime(2022, 1, 1), 0.3)],
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -46,8 +46,9 @@ def model_factory(**model_attributes):
         "household_num_lookahead_years": 3,
         "heating_system_hassle_factor": 0.7,
         "interventions": [],
-        "air_source_heat_pump_discount_factor_2022": 0,
         "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1),
-        "heat_pump_price_discount_schedule": [(datetime.datetime(2022, 1, 1), 0.3)],
+        "air_source_heat_pump_price_discount_schedule": [
+            (datetime.datetime(2023, 1, 1), 0.3)
+        ],
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -153,26 +153,26 @@ class TestCosts:
             mansion, heat_pump
         ) == estimate_rhi_annual_payment(larger_mansion, heat_pump)
 
-    def test_air_source_heat_pumps_get_cheaper_across_2022(self):
+    def test_air_source_heat_pumps_get_cheaper_across_discount_schedule(self):
 
         household = household_factory(heating_system=HeatingSystem.HEAT_PUMP_AIR_SOURCE)
         model = model_factory(
-            start_datetime=datetime.datetime(2022, 1, 1, 0, 0),
-            air_source_heat_pump_discount_factor_2022=0.3,
+            start_datetime=datetime.datetime(2022, 1, 1),
+            air_source_heat_pump_price_discount_schedule=[
+                (datetime.datetime(2023, 1, 1), 0.7),
+            ],
         )
         quote = get_unit_and_install_costs(
             household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
         )
 
-        for n in range(1, 24):
+        for n in range(1, 12):
             model.current_datetime += relativedelta(months=1)
             future_quote = get_unit_and_install_costs(
                 household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
             )
             if n < 12:
                 assert quote > future_quote
-            if n >= 12:
-                assert quote == future_quote
 
             quote = future_quote
 

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -152,6 +152,22 @@ class TestParseArgs:
         args = parse_args([households_file, "path/to/{uuid}/history.jsonl"])
         assert args.history_file == f"path/to/{random_uuid}/history.jsonl"
 
+    def test_heat_pump_price_discount_date_argument(self, mandatory_local_args):
+        args = parse_args(
+            [
+                *mandatory_local_args,
+                "--heat-pump-price-discount-date",
+                "2022-01-01:0.3",
+                "--heat-pump-price-discount-date",
+                "2025-01-01:0.5",
+            ]
+        )
+
+        assert args.heat_pump_price_discount_date == [
+            (datetime.datetime(2022, 1, 1, 0, 0), 0.3),
+            (datetime.datetime(2025, 1, 1, 0, 0), 0.5),
+        ]
+
 
 def assert_histories_equal(first_history, second_history):
     first_agent_history, first_model_history = first_history

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -152,18 +152,20 @@ class TestParseArgs:
         args = parse_args([households_file, "path/to/{uuid}/history.jsonl"])
         assert args.history_file == f"path/to/{random_uuid}/history.jsonl"
 
-    def test_heat_pump_price_discount_date_argument(self, mandatory_local_args):
+    def test_air_source_heat_pump_price_discount_date_argument(
+        self, mandatory_local_args
+    ):
         args = parse_args(
             [
                 *mandatory_local_args,
-                "--heat-pump-price-discount-date",
+                "--air-source-heat-pump-price-discount-date",
                 "2022-01-01:0.3",
-                "--heat-pump-price-discount-date",
+                "--air-source-heat-pump-price-discount-date",
                 "2025-01-01:0.5",
             ]
         )
 
-        assert args.heat_pump_price_discount_date == [
+        assert args.air_source_heat_pump_price_discount_date == [
             (datetime.datetime(2022, 1, 1, 0, 0), 0.3),
             (datetime.datetime(2025, 1, 1, 0, 0), 0.5),
         ]

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -85,7 +85,7 @@ class TestDomesticHeatingABM:
             datetime.datetime(2035, 1, 1): 0.2,
         }
 
-    def test_air_source_heat_pump_discount_factor_is_one_if_no_schedule_passed(self):
+    def test_air_source_heat_pump_discount_factor_is_zero_if_no_schedule_passed(self):
 
         model = model_factory(air_source_heat_pump_price_discount_schedule=[])
 

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -65,7 +65,7 @@ class TestDomesticHeatingABM:
             model.end_datetime: 0,
         }
 
-    def test_heat_pump_price_discount_schedule_generated_for_full_simulation_when_partial_schedule_passed(
+    def test_air_source_heat_pump_price_discount_schedule_generated_for_full_simulation_when_partial_discount_schedule_passed(
         self,
     ) -> None:
 
@@ -85,13 +85,15 @@ class TestDomesticHeatingABM:
             datetime.datetime(2035, 1, 1): 0.2,
         }
 
-    def test_air_source_heat_pump_discount_factor_is_zero_if_no_schedule_passed(self):
+    def test_air_source_heat_pump_discount_factor_is_zero_if_no_discount_schedule_passed(
+        self,
+    ):
 
         model = model_factory(air_source_heat_pump_price_discount_schedule=[])
 
         assert model.air_source_heat_pump_discount_factor == 0
 
-    def test_air_source_heat_pump_discount_factor_declines_if_passed_decreasing_price_schedule(
+    def test_air_source_heat_pump_discount_factor_increases_if_passed_discount_schedule_of_increasing_factors(
         self,
     ):
         model = model_factory(
@@ -107,7 +109,7 @@ class TestDomesticHeatingABM:
         model.increment_timestep()
         second_discount_factor = model.air_source_heat_pump_discount_factor
 
-        assert first_discount_factor < second_discount_factor
+        assert second_discount_factor > first_discount_factor
 
 
 def test_create_household_agents() -> None:

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -85,6 +85,30 @@ class TestDomesticHeatingABM:
             datetime.datetime(2035, 1, 1): 0.7,
         }
 
+    def test_air_source_heat_pump_discount_factor_is_one_if_no_schedule_passed(self):
+
+        model = model_factory(heat_pump_price_discount_schedule=[])
+
+        assert model.heat_pump_discount_factor == 1
+
+    def test_air_source_heat_pump_discount_factor_declines_if_passed_decreasing_price_schedule(
+        self,
+    ):
+        model = model_factory(
+            start_datetime=datetime.datetime(2022, 2, 1),
+            heat_pump_price_discount_schedule=[
+                (datetime.datetime(2022, 2, 1), 1),
+                (datetime.datetime(2022, 4, 1), 0.7),
+            ],
+        )
+
+        first_discount_factor = model.heat_pump_discount_factor
+
+        model.increment_timestep()
+        second_discount_factor = model.heat_pump_discount_factor
+
+        assert second_discount_factor < first_discount_factor
+
 
 def test_create_household_agents() -> None:
     household_population = pd.DataFrame(

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -54,15 +54,15 @@ class TestDomesticHeatingABM:
         model.increment_timestep()
         assert model.boiler_upgrade_scheme_cumulative_spend_gbp == 22_000
 
-    def test_heat_pump_price_discount_schedule_created_when_no_schedule_passed(
+    def test_air_source_heat_pump_price_discount_schedule_created_when_no_schedule_passed(
         self,
     ) -> None:
 
-        model = model_factory(heat_pump_price_discount_schedule=[])
+        model = model_factory(air_source_heat_pump_price_discount_schedule=[])
 
-        assert model.heat_pump_price_discount_schedule == {
-            model.start_datetime: 1,
-            model.end_datetime: 1,
+        assert model.air_source_heat_pump_price_discount_schedule == {
+            model.start_datetime: 0,
+            model.end_datetime: 0,
         }
 
     def test_heat_pump_price_discount_schedule_generated_for_full_simulation_when_partial_schedule_passed(
@@ -72,42 +72,42 @@ class TestDomesticHeatingABM:
         model = model_factory(
             start_datetime=datetime.datetime(2022, 1, 1),
             end_datetime=datetime.datetime(2035, 1, 1),
-            heat_pump_price_discount_schedule=[
-                (datetime.datetime(2023, 1, 1), 0.9),
-                (datetime.datetime(2026, 1, 1), 0.7),
+            air_source_heat_pump_price_discount_schedule=[
+                (datetime.datetime(2023, 1, 1), 0.1),
+                (datetime.datetime(2026, 1, 1), 0.2),
             ],
         )
 
-        assert model.heat_pump_price_discount_schedule == {
-            datetime.datetime(2022, 1, 1): 1,
-            datetime.datetime(2023, 1, 1): 0.9,
-            datetime.datetime(2026, 1, 1): 0.7,
-            datetime.datetime(2035, 1, 1): 0.7,
+        assert model.air_source_heat_pump_price_discount_schedule == {
+            datetime.datetime(2022, 1, 1): 0,
+            datetime.datetime(2023, 1, 1): 0.1,
+            datetime.datetime(2026, 1, 1): 0.2,
+            datetime.datetime(2035, 1, 1): 0.2,
         }
 
     def test_air_source_heat_pump_discount_factor_is_one_if_no_schedule_passed(self):
 
-        model = model_factory(heat_pump_price_discount_schedule=[])
+        model = model_factory(air_source_heat_pump_price_discount_schedule=[])
 
-        assert model.heat_pump_discount_factor == 1
+        assert model.air_source_heat_pump_discount_factor == 0
 
     def test_air_source_heat_pump_discount_factor_declines_if_passed_decreasing_price_schedule(
         self,
     ):
         model = model_factory(
             start_datetime=datetime.datetime(2022, 2, 1),
-            heat_pump_price_discount_schedule=[
-                (datetime.datetime(2022, 2, 1), 1),
-                (datetime.datetime(2022, 4, 1), 0.7),
+            air_source_heat_pump_price_discount_schedule=[
+                (datetime.datetime(2022, 2, 1), 0),
+                (datetime.datetime(2022, 4, 1), 0.3),
             ],
         )
 
-        first_discount_factor = model.heat_pump_discount_factor
+        first_discount_factor = model.air_source_heat_pump_discount_factor
 
         model.increment_timestep()
-        second_discount_factor = model.heat_pump_discount_factor
+        second_discount_factor = model.air_source_heat_pump_discount_factor
 
-        assert second_discount_factor < first_discount_factor
+        assert first_discount_factor < second_discount_factor
 
 
 def test_create_household_agents() -> None:

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -54,6 +54,37 @@ class TestDomesticHeatingABM:
         model.increment_timestep()
         assert model.boiler_upgrade_scheme_cumulative_spend_gbp == 22_000
 
+    def test_heat_pump_price_discount_schedule_created_when_no_schedule_passed(
+        self,
+    ) -> None:
+
+        model = model_factory(heat_pump_price_discount_schedule=[])
+
+        assert model.heat_pump_price_discount_schedule == {
+            model.start_datetime: 1,
+            model.end_datetime: 1,
+        }
+
+    def test_heat_pump_price_discount_schedule_generated_for_full_simulation_when_partial_schedule_passed(
+        self,
+    ) -> None:
+
+        model = model_factory(
+            start_datetime=datetime.datetime(2022, 1, 1),
+            end_datetime=datetime.datetime(2035, 1, 1),
+            heat_pump_price_discount_schedule=[
+                (datetime.datetime(2023, 1, 1), 0.9),
+                (datetime.datetime(2026, 1, 1), 0.7),
+            ],
+        )
+
+        assert model.heat_pump_price_discount_schedule == {
+            datetime.datetime(2022, 1, 1): 1,
+            datetime.datetime(2023, 1, 1): 0.9,
+            datetime.datetime(2026, 1, 1): 0.7,
+            datetime.datetime(2035, 1, 1): 0.7,
+        }
+
 
 def test_create_household_agents() -> None:
     household_population = pd.DataFrame(


### PR DESCRIPTION
- Deprecates `--air-source-heat-pump-discount-factor-2022` and passes `--air-source-heat-pump-price-discount-date` as command line arg instead, which allows for the user to specify any number of `YYYY-MM-DD:price_discount` inputs, to reflect some forecast of air source heat pump price changes
- Adds `model.end_datetime` arg, which is derived from `start_date` and `step_interval` model attributes and the `num_steps` arg passed at runtime. This is used in the below method.
- Adds model method `model.get_heat_pump_price_discount_schedule`, which is a dictionary of {YYYY-MM-DD:price_discount} inclusive of the simulation start and end dates. When households make heating decisions, the model property `model.air_source_heat_pump_discount_factor` infers the discount applicable to the current datetime, linearly interpolating across a discount factor schedule where applicable.