### PR TITLE
Air source heat pump costs change according to specified date schedule

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -104,7 +104,6 @@ def parse_args(args=None):
         "--air-source-heat-pump-price-discount-date",
         action="append",
         type=map_string_to_datetime_float_tuple,
-        default=[],
         help="A factor by which heat pump prices will fall by a specified date.",
         metavar="YYYY-MM-DD:price_discount",
     )

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -28,6 +28,10 @@ def parse_args(args=None):
     def map_string_to_intervention_type_enum(intervention):
         return InterventionType[intervention.upper()]
 
+    def map_string_to_datetime_float_tuple(date_price_discount_string):
+        date, price_discount = date_price_discount_string.split(":")
+        return datetime.datetime.strptime(date, "%Y-%m-%d"), float(price_discount)
+
     parser = argparse.ArgumentParser()
 
     households = parser.add_mutually_exclusive_group(required=True)
@@ -97,10 +101,12 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "--air-source-heat-pump-discount-factor-2022",
-        type=float,
-        default=0.1,
-        help="A factor by which current (2021) air source heat pump unit+install costs will have declined by, as of the end of 2022",
+        "--air-source-heat-pump-price-discount-date",
+        action="append",
+        type=map_string_to_datetime_float_tuple,
+        default=[],
+        help="A factor by which heat pump prices will fall by a specified date.",
+        metavar="YYYY-MM-DD:price_discount",
     )
 
     def check_string_is_isoformat_datetime(string) -> str:
@@ -146,12 +152,12 @@ if __name__ == "__main__":
         args.household_num_lookahead_years,
         args.heating_system_hassle_factor,
         args.intervention,
-        args.air_source_heat_pump_discount_factor_2022,
         args.all_agents_heat_pump_suitable,
         args.gas_oil_boiler_ban_date,
         args.price_gbp_per_kwh_gas,
         args.price_gbp_per_kwh_electricity,
         args.price_gbp_per_kwh_oil,
+        args.air_source_heat_pump_price_discount_date,
     )
 
     if args.history_file.startswith("gs://"):

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -166,9 +166,8 @@ def get_unit_and_install_costs(
 
     if heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
         kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)
-        unit_and_install_costs = (
-            MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity]
-            * model.air_source_heat_pump_discount_factor
+        unit_and_install_costs = MEDIAN_COST_GBP_HEAT_PUMP_AIR_SOURCE[kw_capacity] * (
+            1 - model.air_source_heat_pump_discount_factor
         )
 
         if household.heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -197,7 +197,7 @@ def get_unit_and_install_costs(
     if heating_system == HeatingSystem.BOILER_ELECTRIC:
         costs += MEAN_COST_GBP_BOILER_ELECTRIC[household.property_size]
 
-    return costs
+    return int(costs)
 
 
 def discount_annual_cash_flow(

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -34,8 +34,8 @@ class DomesticHeatingABM(AgentBasedModel):
         price_gbp_per_kwh_gas: float,
         price_gbp_per_kwh_electricity: float,
         price_gbp_per_kwh_oil: float,
-        air_source_heat_pump_price_discount_schedule: List[
-            Tuple[datetime.datetime, float]
+        air_source_heat_pump_price_discount_schedule: Optional[
+            List[Tuple[datetime.datetime, float]]
         ],
     ):
         self.start_datetime = start_datetime
@@ -52,8 +52,10 @@ class DomesticHeatingABM(AgentBasedModel):
             HeatingFuel.ELECTRICITY: price_gbp_per_kwh_electricity,
             HeatingFuel.OIL: price_gbp_per_kwh_oil,
         }
-        self.air_source_heat_pump_price_discount_schedule = sorted(
-            air_source_heat_pump_price_discount_schedule
+        self.air_source_heat_pump_price_discount_schedule = (
+            sorted(air_source_heat_pump_price_discount_schedule)
+            if air_source_heat_pump_price_discount_schedule
+            else None
         )
 
         super().__init__(UnorderedSpace())
@@ -73,9 +75,9 @@ class DomesticHeatingABM(AgentBasedModel):
 
         if self.air_source_heat_pump_price_discount_schedule:
 
-            step_dates, discount_factors = [
-                step for step in zip(*self.air_source_heat_pump_price_discount_schedule)
-            ]
+            step_dates, discount_factors = zip(
+                *self.air_source_heat_pump_price_discount_schedule
+            )
 
             index = bisect(step_dates, self.current_datetime)
             current_date_precedes_first_discount_step = index == 0
@@ -157,7 +159,9 @@ def create_and_run_simulation(
     price_gbp_per_kwh_gas: float,
     price_gbp_per_kwh_electricity: float,
     price_gbp_per_kwh_oil: float,
-    air_source_heat_pump_price_discount_schedule: List[Tuple[datetime.datetime, float]],
+    air_source_heat_pump_price_discount_schedule: Optional[
+        List[Tuple[datetime.datetime, float]]
+    ],
 ):
 
     model = DomesticHeatingABM(

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -49,6 +49,6 @@ def model_factory(**model_attributes):
         "price_gbp_per_kwh_gas": 0.0465,
         "price_gbp_per_kwh_electricity": 0.2006,
         "price_gbp_per_kwh_oil": 0.0482,
-        "air_source_heat_pump_price_discount_schedule": [],
+        "air_source_heat_pump_price_discount_schedule": None,
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -45,10 +45,10 @@ def model_factory(**model_attributes):
         "household_num_lookahead_years": 3,
         "heating_system_hassle_factor": 0.7,
         "interventions": [],
-        "air_source_heat_pump_discount_factor_2022": 0,
         "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1),
         "price_gbp_per_kwh_gas": 0.0465,
         "price_gbp_per_kwh_electricity": 0.2006,
         "price_gbp_per_kwh_oil": 0.0482,
+        "air_source_heat_pump_price_discount_schedule": [],
     }
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -154,7 +154,9 @@ class TestCosts:
             mansion, heat_pump
         ) == estimate_rhi_annual_payment(larger_mansion, heat_pump)
 
-    def test_air_source_heat_pumps_unit_install_costs_are_adjusted_by_discount_factor_across_discount_schedule(self):
+    def test_air_source_heat_pumps_unit_install_costs_are_adjusted_by_discount_factor_across_discount_schedule(
+        self,
+    ):
 
         discount_factor = 0.3
         household = household_factory(heating_system=HeatingSystem.HEAT_PUMP_AIR_SOURCE)

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -154,14 +154,15 @@ class TestCosts:
             mansion, heat_pump
         ) == estimate_rhi_annual_payment(larger_mansion, heat_pump)
 
-    def test_air_source_heat_pumps_get_cheaper_across_discount_schedule(self):
+    def test_air_source_heat_pumps_unit_install_costs_are_adjusted_by_discount_factor_across_discount_schedule(self):
 
+        discount_factor = 0.3
         household = household_factory(heating_system=HeatingSystem.HEAT_PUMP_AIR_SOURCE)
         model = model_factory(
             start_datetime=datetime.datetime(2022, 1, 1),
             step_interval=datetime.timedelta(minutes=1440),
             air_source_heat_pump_price_discount_schedule=[
-                (datetime.datetime(2022, 1, 2), 0.3),
+                (datetime.datetime(2022, 1, 2), discount_factor),
             ],
         )
         first_quote = get_unit_and_install_costs(
@@ -173,7 +174,7 @@ class TestCosts:
             household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
         )
 
-        assert later_quote < first_quote
+        assert later_quote == int((1 - discount_factor) * first_quote)
 
     @pytest.mark.parametrize("boiler", set(BOILERS))
     def test_boiler_upgrade_scheme_grant_is_zero_for_boilers_within_grant_window(

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -2,7 +2,6 @@ import datetime
 import random
 
 import pytest
-from dateutil.relativedelta import relativedelta
 
 from simulation.constants import BOILERS, HEAT_PUMPS, HeatingSystem
 from simulation.costs import (

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -102,6 +102,24 @@ class TestParseArgs:
         pd.testing.assert_frame_equal(args.bigquery, mock_read_gbp.return_value)
         assert args.households is None
 
+    def test_air_source_heat_pump_price_discount_date_argument(
+        self, mandatory_local_args
+    ):
+        args = parse_args(
+            [
+                *mandatory_local_args,
+                "--air-source-heat-pump-price-discount-date",
+                "2022-01-01:0.3",
+                "--air-source-heat-pump-price-discount-date",
+                "2025-01-01:0.5",
+            ]
+        )
+
+        assert args.air_source_heat_pump_price_discount_date == [
+            (datetime.datetime(2022, 1, 1), 0.3),
+            (datetime.datetime(2025, 1, 1), 0.5),
+        ]
+
     def test_bigquery_argument_and_households_file_are_mutually_exclusive(
         self, households_file, output_file, mock_read_gbp
     ):

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -58,7 +58,7 @@ class TestDomesticHeatingABM:
         self,
     ):
 
-        model = model_factory(air_source_heat_pump_price_discount_schedule=[])
+        model = model_factory(air_source_heat_pump_price_discount_schedule=None)
 
         assert model.air_source_heat_pump_discount_factor == 0
 
@@ -69,13 +69,16 @@ class TestDomesticHeatingABM:
         model = model_factory(
             start_datetime=datetime.datetime(2022, 2, 1),
             air_source_heat_pump_price_discount_schedule=[
-                (datetime.datetime(2022, 2, 1), 0),
+                (datetime.datetime(2022, 2, 1), 0.1),
                 (datetime.datetime(2022, 2, 2), 0.3),
             ],
             step_interval=datetime.timedelta(minutes=1440),
         )
 
-        assert model.air_source_heat_pump_discount_factor == 0
+        assert model.air_source_heat_pump_discount_factor == 0.1
+
+        model.increment_timestep()
+        assert model.air_source_heat_pump_discount_factor == 0.3
 
         model.increment_timestep()
         assert model.air_source_heat_pump_discount_factor == 0.3

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -54,6 +54,32 @@ class TestDomesticHeatingABM:
         model.increment_timestep()
         assert model.boiler_upgrade_scheme_cumulative_spend_gbp == 22_000
 
+    def test_air_source_heat_pump_discount_factor_is_zero_if_no_discount_schedule_passed(
+        self,
+    ):
+
+        model = model_factory(air_source_heat_pump_price_discount_schedule=[])
+
+        assert model.air_source_heat_pump_discount_factor == 0
+
+    def test_air_source_heat_pump_discount_factor_changes_when_crosses_discount_schedule_date(
+        self,
+    ):
+
+        model = model_factory(
+            start_datetime=datetime.datetime(2022, 2, 1),
+            air_source_heat_pump_price_discount_schedule=[
+                (datetime.datetime(2022, 2, 1), 0),
+                (datetime.datetime(2022, 2, 2), 0.3),
+            ],
+            step_interval=datetime.timedelta(minutes=1440),
+        )
+
+        assert model.air_source_heat_pump_discount_factor == 0
+
+        model.increment_timestep()
+        assert model.air_source_heat_pump_discount_factor == 0.3
+
 
 def test_create_household_agents() -> None:
     household_population = pd.DataFrame(


### PR DESCRIPTION
- Deprecates `model.air_source_heat_pump_discount_factor_2022` and replaces with `model.air_source_heat_pump_price_discount_date`, enabling the user to more flexibly pass in a (stepped) discount schedule for ASHPs