### PR TITLE
Households with heat pumps are always able to pick heat pumps

### DIFF
--- a/k8s/job.jsonnet
+++ b/k8s/job.jsonnet
@@ -35,17 +35,17 @@ local bigquery_arg = [
 ];
 
 [
-  job('01-%s-baseline' % std.extVar('SHORT_SHA'), [
+  job('01_%s_baseline' % std.extVar('SHORT_SHA'), [
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
   ] + bigquery_arg),
-  job('02-%s-bus' % std.extVar('SHORT_SHA'), [
+  job('02_%s_bus' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
   ] + bigquery_arg),
-  job('03-%s-bus_policy' % std.extVar('SHORT_SHA'), [
+  job('03_%s_bus_policy' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--air-source-heat-pump-price-discount-date',
@@ -57,7 +57,7 @@ local bigquery_arg = [
     '--oil-gbp-per-kwh',
     '0.0702',
   ] + bigquery_arg),
-  job('04-%s-bus_policy_high_awareness' % std.extVar('SHORT_SHA'), [
+  job('04_%s_bus_policy_high_awareness' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--heat-pump-awareness',
@@ -71,7 +71,7 @@ local bigquery_arg = [
     '--oil-gbp-per-kwh',
     '0.0702',
   ] + bigquery_arg),
-  job('05-%s-max_policy' % std.extVar('SHORT_SHA'), [
+  job('05_%s_max_policy' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--intervention',
@@ -87,7 +87,7 @@ local bigquery_arg = [
     '--oil-gbp-per-kwh',
     '0.0702',
   ] + bigquery_arg),
-  job('06-%s-max_industry' % std.extVar('SHORT_SHA'), [
+  job('06_%s_max_industry' % std.extVar('SHORT_SHA'), [
     '--heat-pump-awareness',
     '0.6',
     '--heating-system-hassle-factor',
@@ -98,7 +98,7 @@ local bigquery_arg = [
     '--air-source-heat-pump-price-discount-date',
     '2025-01-01:0.5',
   ] + bigquery_arg),
-  job('07-%s-max_policy_max_industry' % std.extVar('SHORT_SHA'), [
+  job('07_%s_max_policy_max_industry' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--intervention',

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -139,7 +139,9 @@ class Household(Agent):
         self.walls_energy_efficiency = walls_energy_efficiency
         self.roof_energy_efficiency = roof_energy_efficiency
         self.windows_energy_efficiency = windows_energy_efficiency
-        self.is_heat_pump_aware = is_heat_pump_aware
+        self.is_heat_pump_aware = max(
+            self.heating_system in HEAT_PUMPS, is_heat_pump_aware
+        )
 
         # Household investment decision attributes
         self.is_renovating = False
@@ -402,7 +404,7 @@ class Household(Agent):
 
         if not is_gas_oil_boiler_ban_active:
             # if a gas/boiler ban is active, we assume all households are aware of heat pumps
-            if not self.is_heat_pump_aware and self.heating_system not in HEAT_PUMPS:
+            if not self.is_heat_pump_aware:
                 heating_system_options -= HEAT_PUMPS
 
         if self.is_off_gas_grid:
@@ -603,6 +605,7 @@ class Household(Agent):
             if chosen_heating_system in HEAT_PUMPS:
                 upgraded_insulation_elements = chosen_insulation_costs.keys()
                 self.install_insulation_elements(upgraded_insulation_elements)
+                self.is_heat_pump_aware = True
 
             # store all costs associated with heating system decisions as household attributes for simulation logging
             self.heating_system_costs_unit_and_install = costs_unit_and_install

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -402,7 +402,7 @@ class Household(Agent):
 
         if not is_gas_oil_boiler_ban_active:
             # if a gas/boiler ban is active, we assume all households are aware of heat pumps
-            if not self.is_heat_pump_aware:
+            if not self.is_heat_pump_aware and self.heating_system not in HEAT_PUMPS:
                 heating_system_options -= HEAT_PUMPS
 
         if self.is_off_gas_grid:

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -139,8 +139,8 @@ class Household(Agent):
         self.walls_energy_efficiency = walls_energy_efficiency
         self.roof_energy_efficiency = roof_energy_efficiency
         self.windows_energy_efficiency = windows_energy_efficiency
-        self.is_heat_pump_aware = max(
-            self.heating_system in HEAT_PUMPS, is_heat_pump_aware
+        self.is_heat_pump_aware = (
+            self.heating_system in HEAT_PUMPS or is_heat_pump_aware
         )
 
         # Household investment decision attributes

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -615,6 +615,25 @@ class TestHousehold:
             for heating_system in banned_heating_systems
         )
 
+    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_current_heat_pump_always_in_heating_options_for_existing_heat_pump_owners(
+        self,
+        heat_pump,
+        event_trigger,
+    ):
+
+        household_with_heat_pump = household_factory(
+            heating_system=heat_pump,
+            is_heat_pump_aware=False,
+        )
+        model = model_factory()
+        heating_system_options = household_with_heat_pump.get_heating_system_options(
+            model, event_trigger=event_trigger
+        )
+
+        assert heat_pump in heating_system_options
+
     def test_gas_boilers_have_higher_expected_fuel_costs_at_heating_decision_if_gas_prices_increase(
         self,
     ):


### PR DESCRIPTION
- HP ownership (sourced from data warehouse) is disconnected from HP awareness (randomised at simulation). This fixes a logical inconsistency whereby households can own heat pumps but not be aware of them. 
- Note that this will have v. low impact on simulations ran to date due to the simulation time frame (< heating system lifetime), and low initial HP ownership.