### PR TITLE
Ensure heat pump owning households have heat pump awareness

### DIFF
--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -139,7 +139,9 @@ class Household(Agent):
         self.walls_energy_efficiency = walls_energy_efficiency
         self.roof_energy_efficiency = roof_energy_efficiency
         self.windows_energy_efficiency = windows_energy_efficiency
-        self.is_heat_pump_aware = is_heat_pump_aware
+        self.is_heat_pump_aware = (
+            self.heating_system in HEAT_PUMPS or is_heat_pump_aware
+        )
 
         # Household investment decision attributes
         self.is_renovating = False
@@ -603,6 +605,7 @@ class Household(Agent):
             if chosen_heating_system in HEAT_PUMPS:
                 upgraded_insulation_elements = chosen_insulation_costs.keys()
                 self.install_insulation_elements(upgraded_insulation_elements)
+                self.is_heat_pump_aware = True
 
             # store all costs associated with heating system decisions as household attributes for simulation logging
             self.heating_system_costs_unit_and_install = costs_unit_and_install

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -615,6 +615,25 @@ class TestHousehold:
             for heating_system in banned_heating_systems
         )
 
+    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
+    def test_current_heat_pump_always_in_heating_options_for_existing_heat_pump_owners(
+        self,
+        heat_pump,
+        event_trigger,
+    ):
+
+        household_with_heat_pump = household_factory(
+            heating_system=heat_pump,
+            is_heat_pump_aware=False,
+        )
+        model = model_factory()
+        heating_system_options = household_with_heat_pump.get_heating_system_options(
+            model, event_trigger=event_trigger
+        )
+
+        assert heat_pump in heating_system_options
+
     def test_gas_boilers_have_higher_expected_fuel_costs_at_heating_decision_if_gas_prices_increase(
         self,
     ):


### PR DESCRIPTION
- HP ownership (sourced from data warehouse) is disconnected from HP awareness (randomised at simulation). This fixes a logical inconsistency whereby households can own heat pumps but not be aware of them.
- Note that this will have v. low impact on simulations ran to date due to the simulation time frame (< heating system lifetime), and low initial HP ownership.