### PR TITLE
Add heat pump installer capacity to cap heat pump uptake

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -121,6 +121,13 @@ def parse_args(args=None):
         metavar="YYYY-MM-DD:price_discount",
     )
 
+    parser.add_argument(
+        "--heat-pump-installer-annual-growth-rate",
+        type=float,
+        default=0,
+        help="The YoY growth rate of heat pump installers across the UK. A value of 0 indicates no growth.",
+    )
+
     def check_string_is_isoformat_datetime(string) -> str:
         datetime.datetime.fromisoformat(string)
         return string
@@ -181,6 +188,7 @@ if __name__ == "__main__":
             args.price_gbp_per_kwh_electricity,
             args.price_gbp_per_kwh_oil,
             args.air_source_heat_pump_price_discount_date,
+            args.heat_pump_installer_annual_growth_rate,
         )
 
         with smart_open.open(args.history_file, "w") as file:

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -410,6 +410,9 @@ class Household(Agent):
             if not self.is_heat_pump_aware:
                 heating_system_options -= HEAT_PUMPS
 
+        if not model.has_heat_pump_installation_capacity:
+            heating_system_options -= HEAT_PUMPS
+
         if self.is_off_gas_grid:
             heating_system_options -= {HeatingSystem.BOILER_GAS}
         else:
@@ -609,6 +612,7 @@ class Household(Agent):
                 upgraded_insulation_elements = chosen_insulation_costs.keys()
                 self.install_insulation_elements(upgraded_insulation_elements)
                 self.is_heat_pump_aware = True
+                model.heat_pump_installations_at_current_step += 1
 
             # store all costs associated with heating system decisions as household attributes for simulation logging
             self.heating_system_costs_unit_and_install = costs_unit_and_install

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -273,6 +273,10 @@ def model_heat_pump_installation_capacity_per_step(model) -> int:
     return model.heat_pump_installation_capacity_per_step
 
 
+def model_heat_pump_installations_at_current_step(model) -> int:
+    return model.heat_pump_installations_at_current_step
+
+
 def is_first_timestep(model: "DomesticHeatingABM") -> bool:
     return model.current_datetime == model.start_datetime + model.step_interval
 
@@ -347,6 +351,7 @@ def get_model_collectors(
         model_boiler_upgrade_scheme_cumulative_spend_gbp,
         model_heat_pump_installers,
         model_heat_pump_installation_capacity_per_step,
+        model_heat_pump_installations_at_current_step,
         collect_when(model, is_first_timestep)(model_price_gbp_per_kwh_gas),
         collect_when(model, is_first_timestep)(model_price_gbp_per_kwh_electricity),
         collect_when(model, is_first_timestep)(model_price_gbp_per_kwh_oil),

--- a/simulation/collectors.py
+++ b/simulation/collectors.py
@@ -265,6 +265,14 @@ def model_price_gbp_per_kwh_electricity(model) -> float:
     return model.fuel_price_gbp_per_kwh[HeatingFuel.ELECTRICITY]
 
 
+def model_heat_pump_installers(model) -> int:
+    return model.heat_pump_installers
+
+
+def model_heat_pump_installation_capacity_per_step(model) -> int:
+    return model.heat_pump_installation_capacity_per_step
+
+
 def is_first_timestep(model: "DomesticHeatingABM") -> bool:
     return model.current_datetime == model.start_datetime + model.step_interval
 
@@ -337,6 +345,8 @@ def get_model_collectors(
     return [
         model_current_datetime,
         model_boiler_upgrade_scheme_cumulative_spend_gbp,
+        model_heat_pump_installers,
+        model_heat_pump_installation_capacity_per_step,
         collect_when(model, is_first_timestep)(model_price_gbp_per_kwh_gas),
         collect_when(model, is_first_timestep)(model_price_gbp_per_kwh_electricity),
         collect_when(model, is_first_timestep)(model_price_gbp_per_kwh_oil),

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -203,3 +203,7 @@ class InterventionType(enum.Enum):
 
 # Source: https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/families/datasets/householdsbytypeofhouseholdandfamilyregionsofenglandandukconstituentcountries
 ENGLAND_WALES_HOUSEHOLD_COUNT_2020 = 24_600_000
+
+# Source: https://mcscertified.com/
+HEAT_PUMP_INSTALLER_COUNT = 1_700
+HEAT_PUMP_INSTALLATION_DURATION_MONTHS = 0.5

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -206,4 +206,6 @@ ENGLAND_WALES_HOUSEHOLD_COUNT_2020 = 24_600_000
 
 # Source: https://mcscertified.com/
 HEAT_PUMP_INSTALLER_COUNT = 1_700
+
+# Source: https://www.isoenergy.co.uk/latest-news/renewable-energy-news-from-isoenergy/how-long-will-it-take-to-have-a-heat-pump-installed
 HEAT_PUMP_INSTALLATION_DURATION_MONTHS = 0.5

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -68,11 +68,11 @@ class DomesticHeatingABM(AgentBasedModel):
         super().__init__(UnorderedSpace())
 
     @property
-    def household_count(self):
+    def household_count(self) -> int:
         return len(self.space.agents)
 
     @property
-    def heat_pump_installers(self):
+    def heat_pump_installers(self) -> int:
 
         years_elapsed = (self.current_datetime - self.start_datetime).days / 365
         return int(
@@ -81,17 +81,17 @@ class DomesticHeatingABM(AgentBasedModel):
         )
 
     @property
-    def heat_pump_installation_capacity_per_step(self):
+    def heat_pump_installation_capacity_per_step(self) -> int:
 
         months_per_step = self.step_interval.months
         installations_per_installer_per_step = (
             months_per_step / HEAT_PUMP_INSTALLATION_DURATION_MONTHS
         )
 
-        return self.heat_pump_installers * installations_per_installer_per_step
+        return int(self.heat_pump_installers * installations_per_installer_per_step)
 
     @property
-    def has_heat_pump_installation_capacity(self):
+    def has_heat_pump_installation_capacity(self) -> bool:
         return (
             self.heat_pump_installation_capacity_per_step
             > self.heat_pump_installations_at_current_step

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -9,6 +9,7 @@ from abm import AgentBasedModel, UnorderedSpace
 from simulation.agents import Household
 from simulation.collectors import get_agent_collectors, get_model_collectors
 from simulation.constants import (
+    ENGLAND_WALES_HOUSEHOLD_COUNT_2020,
     HEAT_PUMP_INSTALLATION_DURATION_MONTHS,
     HEAT_PUMP_INSTALLER_COUNT,
     HEATING_SYSTEM_LIFETIME_YEARS,
@@ -75,9 +76,17 @@ class DomesticHeatingABM(AgentBasedModel):
     def heat_pump_installers(self) -> int:
 
         years_elapsed = (self.current_datetime - self.start_datetime).days / 365
-        return int(
-            HEAT_PUMP_INSTALLER_COUNT
-            * (1 + self.heat_pump_installer_annual_growth_rate) ** years_elapsed
+        population_scale_factor = (
+            self.household_count / ENGLAND_WALES_HOUSEHOLD_COUNT_2020
+        )
+
+        return max(
+            int(
+                population_scale_factor
+                * HEAT_PUMP_INSTALLER_COUNT
+                * (1 + self.heat_pump_installer_annual_growth_rate) ** years_elapsed
+            ),
+            1,
         )
 
     @property

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -52,6 +52,7 @@ def model_factory(**model_attributes):
         "price_gbp_per_kwh_electricity": 0.2006,
         "price_gbp_per_kwh_oil": 0.0482,
         "air_source_heat_pump_price_discount_schedule": None,
+        "heat_pump_installer_annual_growth_rate": 0,
     }
 
     return DomesticHeatingABM(**{**default_values, **model_attributes})

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -705,3 +705,35 @@ class TestHousehold:
         assert all(
             heating_system in heating_system_options for heating_system in HEAT_PUMPS
         )
+
+    @pytest.mark.parametrize("heating_system", set(HeatingSystem))
+    def test_household_ability_to_choose_heat_pump_as_option_depends_on_model_heat_pump_installation_capacity(
+        self, heating_system
+    ):
+
+        household = household_factory(
+            heating_system=heating_system,
+            is_heat_pump_suitable_archetype=True,
+            is_heat_pump_aware=True,
+        )
+
+        model = model_factory()
+        # heat pump installations exceed model capacity
+        model.heat_pump_installations_at_current_step = (
+            model.heat_pump_installation_capacity_per_step * 1.1
+        )
+        heating_system_options = household.get_heating_system_options(
+            model, event_trigger=EventTrigger.RENOVATION
+        )
+
+        assert all(heat_pump not in heating_system_options for heat_pump in HEAT_PUMPS)
+
+        # heat pump installations are under model capacity
+        model.heat_pump_installations_at_current_step = (
+            model.heat_pump_installation_capacity_per_step * 0.9
+        )
+        heating_system_options = household.get_heating_system_options(
+            model, event_trigger=EventTrigger.RENOVATION
+        )
+
+        assert all(heat_pump in heating_system_options for heat_pump in HEAT_PUMPS)

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -2,6 +2,7 @@ import datetime
 
 import pandas as pd
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from simulation.constants import (
     HEATING_SYSTEM_LIFETIME_YEARS,
@@ -82,6 +83,68 @@ class TestDomesticHeatingABM:
 
         model.increment_timestep()
         assert model.air_source_heat_pump_discount_factor == 0.3
+
+    def test_heat_pump_installers_increases_over_time_with_positive_annaul_growth_rate(
+        self,
+    ):
+
+        model = model_factory(
+            step_interval=relativedelta(months=6),
+            heat_pump_installer_annual_growth_rate=0.5,
+        )
+        heat_pump_installers = model.heat_pump_installers
+
+        model.increment_timestep()
+        future_heat_pump_installers = model.heat_pump_installers
+
+        assert heat_pump_installers < future_heat_pump_installers
+
+    def test_heat_pump_installer_count_increases_faster_with_higher_annual_growth_rate(
+        self,
+    ):
+
+        model = model_factory(
+            step_interval=relativedelta(months=6),
+            heat_pump_installer_annual_growth_rate=0.1,
+        )
+        model.increment_timestep()
+
+        model_with_higher_installer_growth = model_factory(
+            step_interval=relativedelta(months=6),
+            heat_pump_installer_annual_growth_rate=0.3,
+        )
+        model_with_higher_installer_growth.increment_timestep()
+
+        assert (
+            model.heat_pump_installers
+            < model_with_higher_installer_growth.heat_pump_installers
+        )
+
+    def test_heat_pump_installation_capacity_per_step_increases_with_step_interval(
+        self,
+    ):
+
+        model_with_one_month_timestep = model_factory(
+            step_interval=relativedelta(months=1),
+        )
+
+        model_with_six_month_timestep = model_factory(
+            step_interval=relativedelta(months=6),
+        )
+
+        assert (
+            model_with_one_month_timestep.heat_pump_installation_capacity_per_step
+            < model_with_six_month_timestep.heat_pump_installation_capacity_per_step
+        )
+
+    def test_model_does_not_have_heat_pump_installation_capacity_if_installations_per_step_reached_step_capacity(
+        self,
+    ):
+        model = model_factory()
+        model.heat_pump_installations_at_current_step = (
+            model.heat_pump_installation_capacity_per_step * 1.1
+        )
+        assert not model.has_heat_pump_installation_capacity
 
 
 def test_create_household_agents() -> None:

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -84,14 +84,15 @@ class TestDomesticHeatingABM:
         model.increment_timestep()
         assert model.air_source_heat_pump_discount_factor == 0.3
 
-    def test_heat_pump_installers_increases_over_time_with_positive_annaul_growth_rate(
+    def test_heat_pump_installers_increases_over_time_with_positive_annual_growth_rate(
         self,
     ):
 
         model = model_factory(
-            step_interval=relativedelta(months=6),
+            step_interval=relativedelta(months=60),
             heat_pump_installer_annual_growth_rate=0.5,
         )
+        model.add_agents([household_factory() for _ in range(10_000)])
         heat_pump_installers = model.heat_pump_installers
 
         model.increment_timestep()
@@ -104,14 +105,18 @@ class TestDomesticHeatingABM:
     ):
 
         model = model_factory(
-            step_interval=relativedelta(months=6),
+            step_interval=relativedelta(months=120),
             heat_pump_installer_annual_growth_rate=0.1,
         )
+        model.add_agents([household_factory() for _ in range(10_000)])
         model.increment_timestep()
 
         model_with_higher_installer_growth = model_factory(
-            step_interval=relativedelta(months=6),
-            heat_pump_installer_annual_growth_rate=0.3,
+            step_interval=relativedelta(months=120),
+            heat_pump_installer_annual_growth_rate=0.6,
+        )
+        model_with_higher_installer_growth.add_agents(
+            [household_factory() for _ in range(10_000)]
         )
         model_with_higher_installer_growth.increment_timestep()
 


### PR DESCRIPTION
- Enables user to pass in a factor for annual heat pump installer growth, which in turn with defaults specified for the time taken to install a heat pump, limits the number of heat pumps which can be installed in a given step. In this way, we prevent heat pump uptake  exceeding some plausible/forecasted heat pump installer capacity.
- With the defaults provided, the implied heat pump installation capacity is 3,400 installs/month or 40k installs/year, which approximately aligns with estimates of 35k currently being installed in the UK per year ([page 8](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1026356/domestic-offgg-consultation.pdf))
- Similarly to the Boiler Upgrade Scheme budget, the heat pump installer count is scaled to the actual simulated population to avoid non-meaningful scenarios (e.g. 1,000 agents having access to 1,700 heat pump installers).