### PR TITLE
Add floor for ASHP cost at price of a gas boiler

### DIFF
--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -160,8 +160,6 @@ def get_unit_and_install_costs(
 ) -> int:
 
     costs = 0
-    # Any projected heat pump discounts are capped at the price of a gas boiler for a household
-    heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
     if heating_system != household.heating_system:
         decommissioning_costs = random.randint(500, 2_000)
@@ -176,6 +174,9 @@ def get_unit_and_install_costs(
         if household.heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
             # Some installation work required to install a heat pump first time does not apply to 2nd+ installations
             unit_and_install_costs *= 1 - HEAT_PUMP_AIR_SOURCE_REINSTALL_DISCOUNT
+
+        # Any projected heat pump discounts are capped at the price of a gas boiler for a household
+        heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
         costs += max(unit_and_install_costs, heat_pump_price_floor)
 

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -160,6 +160,8 @@ def get_unit_and_install_costs(
 ) -> int:
 
     costs = 0
+    # Any projected heat pump discounts are capped at the price of a gas boiler for a household
+    heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
     if heating_system != household.heating_system:
         decommissioning_costs = random.randint(500, 2_000)
@@ -173,21 +175,19 @@ def get_unit_and_install_costs(
 
         if household.heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:
             # Some installation work required to install a heat pump first time does not apply to 2nd+ installations
-            costs += unit_and_install_costs * (
-                1 - HEAT_PUMP_AIR_SOURCE_REINSTALL_DISCOUNT
-            )
-        else:
-            costs += unit_and_install_costs
+            unit_and_install_costs *= 1 - HEAT_PUMP_AIR_SOURCE_REINSTALL_DISCOUNT
+
+        costs += max(unit_and_install_costs, heat_pump_price_floor)
 
     if heating_system == HeatingSystem.HEAT_PUMP_GROUND_SOURCE:
         kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)
+        unit_and_install_costs = MEDIAN_COST_GBP_HEAT_PUMP_GROUND_SOURCE[kw_capacity]
+
         if household.heating_system == HeatingSystem.HEAT_PUMP_GROUND_SOURCE:
             # Some installation work required to install a heat pump first time does not apply to 2nd+ installations
-            costs += MEDIAN_COST_GBP_HEAT_PUMP_GROUND_SOURCE[kw_capacity] * (
-                1 - HEAT_PUMP_GROUND_SOURCE_REINSTALL_DISCOUNT
-            )
-        else:
-            costs += MEDIAN_COST_GBP_HEAT_PUMP_GROUND_SOURCE[kw_capacity]
+            unit_and_install_costs *= 1 - HEAT_PUMP_GROUND_SOURCE_REINSTALL_DISCOUNT
+
+        costs += max(unit_and_install_costs, heat_pump_price_floor)
 
     if heating_system == HeatingSystem.BOILER_GAS:
         costs += MEAN_COST_GBP_BOILER_GAS[household.property_size]

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -187,7 +187,7 @@ def get_unit_and_install_costs(
             # Some installation work required to install a heat pump first time does not apply to 2nd+ installations
             unit_and_install_costs *= 1 - HEAT_PUMP_GROUND_SOURCE_REINSTALL_DISCOUNT
 
-        costs += max(unit_and_install_costs, heat_pump_price_floor)
+        costs += unit_and_install_costs
 
     if heating_system == HeatingSystem.BOILER_GAS:
         costs += MEAN_COST_GBP_BOILER_GAS[household.property_size]

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -152,6 +152,9 @@ MEAN_COST_GBP_BOILER_ELECTRIC: Dict[PropertySize, int] = {
 HEAT_PUMP_AIR_SOURCE_REINSTALL_DISCOUNT = 0.1
 HEAT_PUMP_GROUND_SOURCE_REINSTALL_DISCOUNT = 0.5
 
+# Source: Distribution based on values in https://www.theccc.org.uk/publication/analysis-of-alternative-uk-heat-decarbonisation-pathways/
+DECOMMISSIONING_COST_MIN, DECOMMISSIONING_COST_MAX = 500, 2_000
+
 
 def get_unit_and_install_costs(
     household: "Household",
@@ -162,7 +165,9 @@ def get_unit_and_install_costs(
     costs = 0
 
     if heating_system != household.heating_system:
-        decommissioning_costs = random.randint(500, 2_000)
+        decommissioning_costs = random.randint(
+            DECOMMISSIONING_COST_MIN, DECOMMISSIONING_COST_MAX
+        )
         costs += decommissioning_costs
 
     if heating_system == HeatingSystem.HEAT_PUMP_AIR_SOURCE:

--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -180,10 +180,10 @@ def get_unit_and_install_costs(
             # Some installation work required to install a heat pump first time does not apply to 2nd+ installations
             unit_and_install_costs *= 1 - HEAT_PUMP_AIR_SOURCE_REINSTALL_DISCOUNT
 
-        # Any projected heat pump discounts are capped at the price of a gas boiler for a household
-        heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
+        # Any projected air source heat pump discounts are capped at the price of a gas boiler for a household
+        ashp_price_min_cap = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
-        costs += max(unit_and_install_costs, heat_pump_price_floor)
+        costs += max(unit_and_install_costs, ashp_price_min_cap)
 
     if heating_system == HeatingSystem.HEAT_PUMP_GROUND_SOURCE:
         kw_capacity = household.compute_heat_pump_capacity_kw(heating_system)

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -274,9 +274,9 @@ class TestCosts:
         heat_pump_cost = get_unit_and_install_costs(
             household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
         )
-        heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
+        ashp_price_min_cap = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
-        assert heat_pump_cost == heat_pump_price_floor
+        assert heat_pump_cost == ashp_price_min_cap
 
     def test_air_source_heat_pump_unit_and_install_costs_floored_at_gas_boiler_plus_decommissioning_costs_for_households_switching_heating_system(
         self,
@@ -292,6 +292,6 @@ class TestCosts:
         heat_pump_cost = get_unit_and_install_costs(
             household, HeatingSystem.HEAT_PUMP_AIR_SOURCE, model
         )
-        heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
+        ashp_price_min_cap = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
-        assert heat_pump_cost <= heat_pump_price_floor + DECOMMISSIONING_COST_MAX
+        assert heat_pump_cost <= ashp_price_min_cap + DECOMMISSIONING_COST_MAX

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -10,6 +10,7 @@ from simulation.constants import (
     HeatingSystem,
 )
 from simulation.costs import (
+    DECOMMISSIONING_COST_MAX,
     MEAN_COST_GBP_BOILER_GAS,
     estimate_boiler_upgrade_scheme_grant,
     estimate_rhi_annual_payment,
@@ -293,7 +294,4 @@ class TestCosts:
         )
         heat_pump_price_floor = MEAN_COST_GBP_BOILER_GAS[household.property_size]
 
-        # Decommissioning costs for changing heating system type are randomly generated between 500-2_000 GBP
-        decommission_cost_max = 2_000
-
-        assert heat_pump_cost <= heat_pump_price_floor + decommission_cost_max
+        assert heat_pump_cost <= heat_pump_price_floor + DECOMMISSIONING_COST_MAX


### PR DESCRIPTION
- Floors the price of an air source heat pump to the price that a given household would pay for a gas boiler. Note that all decommissioning costs sit independently of projected unit costs - therefore for a household _switching_ heating system, they will still experience these decommissioning costs on top of the floored price.
- Also refactors the function `costs.get_unit_and_install_costs()` for clearer code in the process.