### PR TITLE
Households exclude to-be-banned systems as options, ahead of ban

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -150,7 +150,7 @@ def parse_args(args=None):
 
     parser.add_argument(
         "--gas-oil-boiler-ban-announce-date",
-        default=datetime.datetime(2025, 1, 1),
+        default=datetime.datetime(2035, 1, 1),
         type=convert_to_datetime,
     )
 
@@ -163,8 +163,17 @@ def parse_args(args=None):
     return parser.parse_args(args)
 
 
+def validate_args(args):
+    if args.gas_oil_boiler_ban_announce_date > args.gas_oil_boiler_ban_date:
+        raise ValueError(
+            f"Boiler ban announcement date must be on or before ban date, got gas_oil_boiler_ban_date:{args.gas_oil_boiler_ban_date}, gas_oil_boiler_ban_announce_date:{args.gas_oil_boiler_ban_announce_date}"
+        )
+
+
 if __name__ == "__main__":
+
     args = parse_args()
+    validate_args(args)
 
     logger.info(
         "parsed arguments",

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -148,6 +148,12 @@ def parse_args(args=None):
         type=convert_to_datetime,
     )
 
+    parser.add_argument(
+        "--gas-oil-boiler-ban-announce-date",
+        default=datetime.datetime(2025, 1, 1),
+        type=convert_to_datetime,
+    )
+
     # SOURCE: Default values from https://energysavingtrust.org.uk/about-us/our-data/ (England, Scotland and Wales)
     # These fuel prices were last updated in November 2021, based on predicted fuel prices for 2022
     parser.add_argument("--price-gbp-per-kwh-gas", type=float, default=0.0465)
@@ -184,6 +190,7 @@ if __name__ == "__main__":
             args.intervention,
             args.all_agents_heat_pump_suitable,
             args.gas_oil_boiler_ban_date,
+            args.gas_oil_boiler_ban_announce_date,
             args.price_gbp_per_kwh_gas,
             args.price_gbp_per_kwh_electricity,
             args.price_gbp_per_kwh_oil,

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -28,6 +28,7 @@ from simulation.constants import (
     HEATING_KWH_PER_SQM_ANNUAL,
     HEATING_PROPORTION_OF_RENO_BUDGET,
     HEATING_SYSTEM_FUEL,
+    MAX_BAN_LEAD_TIME_YEARS,
     MAX_HEAT_PUMP_CAPACITY_KW,
     MIN_HEAT_PUMP_CAPACITY_KW,
     RENO_NUM_INSULATION_ELEMENTS_UPGRADED,
@@ -96,7 +97,7 @@ def weibull_hazard_rate(alpha: float, beta: float, age_years: float) -> float:
 
 def reverse_sigmoid(x: float, k: float = SIGMOID_K, offset: float = SIGMOID_OFFSET):
 
-    return 1 / (1 + math.exp(-k * (-x - offset)))
+    return 1 / (1 + math.exp(k * (x + offset)))
 
 
 class Household(Agent):
@@ -407,8 +408,7 @@ class Household(Agent):
             model.gas_oil_boiler_ban_datetime - model.current_datetime
         ).days / 365
 
-        max_ban_lead_time_years = 10
-        if years_to_ban > max_ban_lead_time_years:
+        if years_to_ban > MAX_BAN_LEAD_TIME_YEARS:
             return 0
 
         return reverse_sigmoid(years_to_ban)

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -94,9 +94,9 @@ def weibull_hazard_rate(alpha: float, beta: float, age_years: float) -> float:
     return (alpha / beta) * (age_years / beta) ** (alpha - 1)
 
 
-def sigmoid(x: float, k: float = SIGMOID_K, offset: float = SIGMOID_OFFSET):
+def reverse_sigmoid(x: float, k: float = SIGMOID_K, offset: float = SIGMOID_OFFSET):
 
-    return 1 / (1 + math.exp(-k * (x - offset)))
+    return 1 / (1 + math.exp(-k * (-x - offset)))
 
 
 class Household(Agent):
@@ -403,15 +403,15 @@ class Household(Agent):
         if model.current_datetime >= model.gas_oil_boiler_ban_datetime:
             return 1
 
-        max_ban_lead_time_years = 10
         years_to_ban = (
             model.gas_oil_boiler_ban_datetime - model.current_datetime
         ).days / 365
 
+        max_ban_lead_time_years = 10
         if years_to_ban > max_ban_lead_time_years:
             return 0
 
-        return sigmoid(max_ban_lead_time_years - years_to_ban)
+        return reverse_sigmoid(years_to_ban)
 
     def get_heating_system_options(
         self, model: "DomesticHeatingABM", event_trigger: EventTrigger

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -57,6 +57,9 @@ HEATING_SYSTEM_LIFETIME_YEARS = 15
 HAZARD_RATE_HEATING_SYSTEM_ALPHA = 6
 HAZARD_RATE_HEATING_SYSTEM_BETA = 15
 
+SIGMOID_K = 1
+SIGMOID_OFFSET = 7
+
 
 class ConstructionYearBand(enum.Enum):
     # These categories match the England & Wales EPC categories

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -57,6 +57,9 @@ HEATING_SYSTEM_LIFETIME_YEARS = 15
 HAZARD_RATE_HEATING_SYSTEM_ALPHA = 6
 HAZARD_RATE_HEATING_SYSTEM_BETA = 15
 
+# If a ban is active and has been announced, irrespective of the `SIGMOID_{K, OFFSET}` values,
+# all agents will not consider banned heating systems after this time
+MAX_BAN_LEAD_TIME_YEARS = 10
 SIGMOID_K = 1
 SIGMOID_OFFSET = 7
 

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -34,6 +34,7 @@ class DomesticHeatingABM(AgentBasedModel):
         heating_system_hassle_factor: float,
         interventions: Optional[List[InterventionType]],
         gas_oil_boiler_ban_datetime: datetime.datetime,
+        gas_oil_boiler_ban_announce_datetime: datetime.datetime,
         price_gbp_per_kwh_gas: float,
         price_gbp_per_kwh_electricity: float,
         price_gbp_per_kwh_oil: float,
@@ -51,6 +52,7 @@ class DomesticHeatingABM(AgentBasedModel):
         self.interventions = interventions or []
         self.boiler_upgrade_scheme_cumulative_spend_gbp = 0
         self.gas_oil_boiler_ban_datetime = gas_oil_boiler_ban_datetime
+        self.gas_oil_boiler_ban_announce_datetime = gas_oil_boiler_ban_announce_datetime
         self.fuel_price_gbp_per_kwh = {
             HeatingFuel.GAS: price_gbp_per_kwh_gas,
             HeatingFuel.ELECTRICITY: price_gbp_per_kwh_electricity,
@@ -203,6 +205,7 @@ def create_and_run_simulation(
     interventions: Optional[List[InterventionType]],
     all_agents_heat_pump_suitable: bool,
     gas_oil_boiler_ban_datetime: datetime.datetime,
+    gas_oil_boiler_ban_announce_datetime: datetime.datetime,
     price_gbp_per_kwh_gas: float,
     price_gbp_per_kwh_electricity: float,
     price_gbp_per_kwh_oil: float,
@@ -220,6 +223,7 @@ def create_and_run_simulation(
         heating_system_hassle_factor=heating_system_hassle_factor,
         interventions=interventions,
         gas_oil_boiler_ban_datetime=gas_oil_boiler_ban_datetime,
+        gas_oil_boiler_ban_announce_datetime=gas_oil_boiler_ban_announce_datetime,
         price_gbp_per_kwh_gas=price_gbp_per_kwh_gas,
         price_gbp_per_kwh_electricity=price_gbp_per_kwh_electricity,
         price_gbp_per_kwh_oil=price_gbp_per_kwh_oil,

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -48,6 +48,7 @@ def model_factory(**model_attributes):
         "heating_system_hassle_factor": 0.7,
         "interventions": [],
         "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1),
+        "gas_oil_boiler_ban_announce_datetime": datetime.datetime(2025, 1, 1),
         "price_gbp_per_kwh_gas": 0.0465,
         "price_gbp_per_kwh_electricity": 0.2006,
         "price_gbp_per_kwh_oil": 0.0482,

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -48,7 +48,7 @@ def model_factory(**model_attributes):
         "heating_system_hassle_factor": 0.7,
         "interventions": [],
         "gas_oil_boiler_ban_datetime": datetime.datetime(2035, 1, 1),
-        "gas_oil_boiler_ban_announce_datetime": datetime.datetime(2025, 1, 1),
+        "gas_oil_boiler_ban_announce_datetime": datetime.datetime(2035, 1, 1),
         "price_gbp_per_kwh_gas": 0.0465,
         "price_gbp_per_kwh_electricity": 0.2006,
         "price_gbp_per_kwh_oil": 0.0482,

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -737,3 +737,93 @@ class TestHousehold:
         )
 
         assert all(heat_pump in heating_system_options for heat_pump in HEAT_PUMPS)
+
+    def test_households_increasingly_likely_to_rule_out_heating_systems_that_will_be_banned_as_time_to_ban_decreases(
+        self,
+    ):
+
+        household = household_factory()
+        model = model_factory(
+            start_datetime=datetime.datetime(2026, 1, 1),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_announce_datetime=datetime.datetime(2025, 1, 1),
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
+        )
+
+        proba_rule_out_banned_boilers = (
+            household.get_proba_rule_out_banned_heating_systems(model)
+        )
+
+        model.increment_timestep()
+        proba_rule_out_banned_boilers_updated = (
+            household.get_proba_rule_out_banned_heating_systems(model)
+        )
+
+        assert proba_rule_out_banned_boilers < proba_rule_out_banned_boilers_updated
+
+    def test_household_proba_rule_out_banned_heating_systems_is_one_if_ban_is_active(
+        self,
+    ):
+
+        household = household_factory()
+        model = model_factory(
+            start_datetime=datetime.datetime(2031, 1, 1),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_announce_datetime=datetime.datetime(2025, 1, 1),
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
+        )
+
+        proba_rule_out_banned_boilers = (
+            household.get_proba_rule_out_banned_heating_systems(model)
+        )
+        assert proba_rule_out_banned_boilers == 1
+
+    def test_household_proba_rule_out_banned_heating_systems_is_zero_if_more_than_10_years_til_ban_is_active(
+        self,
+    ):
+
+        household = household_factory()
+        model = model_factory(
+            start_datetime=datetime.datetime(2028, 1, 1),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_announce_datetime=datetime.datetime(2025, 1, 1),
+            gas_oil_boiler_ban_datetime=datetime.datetime(2040, 1, 1),
+        )
+
+        proba_rule_out_banned_boilers = (
+            household.get_proba_rule_out_banned_heating_systems(model)
+        )
+        assert proba_rule_out_banned_boilers == 0
+
+    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    @pytest.mark.parametrize("heating_system", set(HeatingSystem))
+    def test_households_rule_out_banned_heating_systems_only_once_ban_is_announced(
+        self, event_trigger, heating_system
+    ):
+
+        household = household_factory(heating_system=heating_system)
+        model = model_factory(
+            start_datetime=datetime.datetime(2029, 12, 31),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_announce_datetime=datetime.datetime(2030, 1, 1),
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
+        )
+
+        banned_boilers = [HeatingSystem.BOILER_GAS, HeatingSystem.BOILER_OIL]
+        heating_system_options = household.get_heating_system_options(
+            model, event_trigger=event_trigger
+        )
+
+        assert any(
+            banned_boiler in heating_system_options for banned_boiler in banned_boilers
+        )
+
+        model.increment_timestep()
+        heating_system_options = household.get_heating_system_options(
+            model, event_trigger=event_trigger
+        )
+
+        assert all(
+            banned_boiler not in heating_system_options
+            for banned_boiler in banned_boilers
+        )

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -596,29 +596,6 @@ class TestHousehold:
         )
 
     @pytest.mark.parametrize("event_trigger", set(EventTrigger))
-    def test_gas_and_oil_boilers_are_not_in_heating_options_if_gas_oil_ban_intervention_active(
-        self, event_trigger
-    ):
-
-        household = household_factory(heating_system=random.choices(list(BOILERS))[0])
-
-        model_with_gas_oil_boiler_ban = model_factory(
-            start_datetime=datetime.datetime(2035, 3, 1),
-            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
-            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
-        )
-
-        banned_heating_systems = [HeatingSystem.BOILER_GAS, HeatingSystem.BOILER_OIL]
-        heating_system_options = household.get_heating_system_options(
-            model_with_gas_oil_boiler_ban, event_trigger=event_trigger
-        )
-
-        assert all(
-            heating_system not in heating_system_options
-            for heating_system in banned_heating_systems
-        )
-
-    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
     @pytest.mark.parametrize("heat_pump", HEAT_PUMPS)
     def test_current_heat_pump_always_in_heating_options_for_existing_heat_pump_owners(
         self,
@@ -678,34 +655,6 @@ class TestHousehold:
             model
         ) < household.annual_heating_fuel_bill(model_with_increased_fuel_prices)
 
-    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
-    @pytest.mark.parametrize("is_heat_pump_aware", [True, False])
-    def test_heat_pump_suitable_households_can_choose_heat_pumps_in_all_event_triggers_and_irrespective_of_awareness_if_gas_oil_ban_intervention_active(
-        self,
-        event_trigger,
-        is_heat_pump_aware,
-    ):
-
-        household = household_factory(
-            heating_system=random.choices(list(BOILERS))[0],
-            is_heat_pump_aware=is_heat_pump_aware,
-            is_heat_pump_suitable_archetype=True,
-        )
-
-        model_with_gas_oil_boiler_ban = model_factory(
-            start_datetime=datetime.datetime(2035, 3, 1),
-            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
-            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
-        )
-
-        heating_system_options = household.get_heating_system_options(
-            model_with_gas_oil_boiler_ban, event_trigger=event_trigger
-        )
-
-        assert all(
-            heating_system in heating_system_options for heating_system in HEAT_PUMPS
-        )
-
     @pytest.mark.parametrize("heating_system", set(HeatingSystem))
     def test_household_ability_to_choose_heat_pump_as_option_depends_on_model_heat_pump_installation_capacity(
         self, heating_system
@@ -738,10 +687,11 @@ class TestHousehold:
 
         assert all(heat_pump in heating_system_options for heat_pump in HEAT_PUMPS)
 
+
+class TestAgentsWithBoilerBan:
     def test_households_increasingly_likely_to_rule_out_heating_systems_that_will_be_banned_as_time_to_ban_decreases(
         self,
     ):
-
         household = household_factory()
         model = model_factory(
             start_datetime=datetime.datetime(2026, 1, 1),
@@ -826,4 +776,55 @@ class TestHousehold:
         assert all(
             banned_boiler not in heating_system_options
             for banned_boiler in banned_boilers
+        )
+
+    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    def test_gas_and_oil_boilers_are_not_in_heating_options_if_gas_oil_ban_intervention_active(
+        self, event_trigger
+    ):
+
+        household = household_factory(heating_system=random.choices(list(BOILERS))[0])
+
+        model_with_gas_oil_boiler_ban = model_factory(
+            start_datetime=datetime.datetime(2035, 3, 1),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
+        )
+
+        banned_heating_systems = [HeatingSystem.BOILER_GAS, HeatingSystem.BOILER_OIL]
+        heating_system_options = household.get_heating_system_options(
+            model_with_gas_oil_boiler_ban, event_trigger=event_trigger
+        )
+
+        assert all(
+            heating_system not in heating_system_options
+            for heating_system in banned_heating_systems
+        )
+
+    @pytest.mark.parametrize("event_trigger", set(EventTrigger))
+    @pytest.mark.parametrize("is_heat_pump_aware", [True, False])
+    def test_heat_pump_suitable_households_can_choose_heat_pumps_in_all_event_triggers_and_irrespective_of_awareness_if_gas_oil_ban_intervention_active(
+        self,
+        event_trigger,
+        is_heat_pump_aware,
+    ):
+
+        household = household_factory(
+            heating_system=random.choices(list(BOILERS))[0],
+            is_heat_pump_aware=is_heat_pump_aware,
+            is_heat_pump_suitable_archetype=True,
+        )
+
+        model_with_gas_oil_boiler_ban = model_factory(
+            start_datetime=datetime.datetime(2035, 3, 1),
+            interventions=[InterventionType.GAS_OIL_BOILER_BAN],
+            gas_oil_boiler_ban_datetime=datetime.datetime(2030, 1, 1),
+        )
+
+        heating_system_options = household.get_heating_system_options(
+            model_with_gas_oil_boiler_ban, event_trigger=event_trigger
+        )
+
+        assert all(
+            heating_system in heating_system_options for heating_system in HEAT_PUMPS
         )

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 
 import simulation.__main__
 from abm import read_jsonlines
-from simulation.__main__ import parse_args
+from simulation.__main__ import parse_args, validate_args
 from simulation.constants import InterventionType
 
 
@@ -250,3 +250,20 @@ def test_running_simulation_twice_with_same_seed_gives_identical_results(
 
 def test_python_hash_randomization_is_disabled():
     assert os.environ["PYTHONHASHSEED"] == "0"
+
+
+class TestValidateArgs:
+    def test_ban_date_before_announcement_date_raises_value_error(
+        self, mandatory_local_args
+    ):
+        args = parse_args(
+            [
+                *mandatory_local_args,
+                "--gas-oil-boiler-ban-date",
+                "2025-01-01",
+                "--gas-oil-boiler-ban-announce-date",
+                "2030-01-01",
+            ]
+        )
+        with pytest.raises(ValueError):
+            validate_args(args)


### PR DESCRIPTION
- Context: Prior to this PR, households would always ignore the existence of an upcoming ban and react only when the ban is live. This results in a sharp, angular uptake in HPs as of the ban date.
- This PR introduces the possibility of households responding to the ban before it is live - a proportion of households will exclude to-be-banned systems (oil/gas boilers) from their heating system options if the ban has been announced. The proportion of households doing this depends upon the time til the ban. When the ban is live, this is always 100%. When the ban is more than 10 years away, this is always 0%. When the ban is between 0-10 years away, this is determined by a parameterised sigmoid curve (see below). The curve's parameters can be considered placeholder values subject to further research / a future PR.

![image](https://user-images.githubusercontent.com/82801691/152119357-1cff877f-3cb3-4ba9-b9b3-1b4a550b7838.png)

Note: The announcement date can be interpreted specifically as a statement from Government _which leaves no room for uncertainty_. Expected behaviour is that the longer uncertainty persists or a lack of formal ban is put in place (i.e. the less time between announcement and ban dates), the less able heat pump installers are to work at capacity pre-ban and meet the uptick in post-ban demand. For the same ban date, a delay in announcement therefore reduces overall HP uptake.

<img width="696" alt="Screenshot 2022-02-02 at 10 02 02" src="https://user-images.githubusercontent.com/82801691/152132706-0a00da86-0911-463d-a602-506b1acb29f1.png">

<img width="692" alt="Screenshot 2022-02-02 at 10 02 15" src="https://user-images.githubusercontent.com/82801691/152132731-5257a4e2-295b-44f6-84c6-e21a80245fe2.png">

