### PR TITLE
Update default hp installer growth rate and cap total installer count

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -124,7 +124,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--heat-pump-installer-annual-growth-rate",
         type=float,
-        default=0,
+        default=0.565,
         help="The YoY growth rate of heat pump installers across the UK. A value of 0 indicates no growth.",
     )
 

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -215,3 +215,8 @@ HEAT_PUMP_INSTALLER_COUNT = 1_700
 
 # Source: https://www.isoenergy.co.uk/latest-news/renewable-energy-news-from-isoenergy/how-long-will-it-take-to-have-a-heat-pump-installed
 HEAT_PUMP_INSTALLATION_DURATION_MONTHS = 0.5
+
+# Source: https://ukerc.ac.uk/news/heating-engineers-skills-and-heat-decarbonisation/
+# Assuming a 1:1 replacement of gas engineer to heat pump engineers
+# In 2019, 130K heating engineers registered with Gas Safe; 28mil households = 215 households to every installer
+HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR = 215

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -13,6 +13,7 @@ from simulation.constants import (
     HEAT_PUMP_INSTALLATION_DURATION_MONTHS,
     HEAT_PUMP_INSTALLER_COUNT,
     HEATING_SYSTEM_LIFETIME_YEARS,
+    HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR,
     BuiltForm,
     ConstructionYearBand,
     EPCRating,
@@ -82,7 +83,7 @@ class DomesticHeatingABM(AgentBasedModel):
             self.household_count / ENGLAND_WALES_HOUSEHOLD_COUNT_2020
         )
 
-        return max(
+        heat_pump_installers = max(
             int(
                 population_scale_factor
                 * HEAT_PUMP_INSTALLER_COUNT
@@ -90,6 +91,16 @@ class DomesticHeatingABM(AgentBasedModel):
             ),
             1,
         )
+
+        if (
+            self.household_count / heat_pump_installers
+            < HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR
+        ):
+            return max(
+                int(self.household_count / HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR), 1
+            )
+
+        return heat_pump_installers
 
     @property
     def heat_pump_installation_capacity_per_step(self) -> int:

--- a/simulation/tests/test_model.py
+++ b/simulation/tests/test_model.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 
 from simulation.constants import (
     HEATING_SYSTEM_LIFETIME_YEARS,
+    HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR,
     BuiltForm,
     ConstructionYearBand,
     EPCRating,
@@ -124,6 +125,22 @@ class TestDomesticHeatingABM:
             model.heat_pump_installers
             < model_with_higher_installer_growth.heat_pump_installers
         )
+
+    def test_heat_pump_installer_count_is_capped_by_ratio_of_installers_to_households(
+        self,
+    ):
+
+        model = model_factory(
+            step_interval=relativedelta(months=120),
+            heat_pump_installer_annual_growth_rate=9,
+        )
+        model.add_agents([household_factory() for _ in range(10_000)])
+        model.increment_timestep()
+
+        hp_installer_maximum = int(
+            model.household_count / HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR
+        )
+        assert model.heat_pump_installers == hp_installer_maximum
 
     def test_heat_pump_installation_capacity_per_step_increases_with_step_interval(
         self,


### PR DESCRIPTION
- Updates the default HP installer growth rate to 56.5%. Rationale:

> HPs per year (by 2028) = 600,000
> HPs installed by 1 installer per year = 24
> Implied installer count in at 2028 = 25,000
> Starting from a baseline of 1,700 HP installers, a default annual growth rate of 56.5% would result in ~25k installers in 6 years time (by 2028).

- Caps the total number of HP installers to avoid exponential growth under certain inputs. The current ratio of households to gas engineers is used as a floor, and implicitly assumes a 1:1 replacement of gas engineer to heat pump engineers in the future.