### PR TITLE
Modify simulation parameters and scenario specifications

### DIFF
--- a/k8s/job.jsonnet
+++ b/k8s/job.jsonnet
@@ -40,25 +40,29 @@ local bigquery_arg = [
 ];
 
 [
-  job('00-%s-rhi' % std.extVar('SHORT_SHA'), [
+  job('01-%s-rhi' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'rhi',
     '--start-date',
     '2012-01-01',
     '--steps',
     '120',
+    '--heat-pump-installer-count',
+    '1_800',
+     '--heat-pump-installer-annual-growth-rate',
+    '0',
   ] + bigquery_arg),
-  job('01-%s-baseline' % std.extVar('SHORT_SHA'), [
+  job('02-%s-baseline' % std.extVar('SHORT_SHA'), [
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
   ] + bigquery_arg),
-  job('02-%s-bus' % std.extVar('SHORT_SHA'), [
+  job('03a-%s-bus' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
   ] + bigquery_arg),
-  job('03a-%s-bus-policy' % std.extVar('SHORT_SHA'), [
+  job('03b-%s-bus-policy' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--air-source-heat-pump-price-discount-date',
@@ -70,11 +74,11 @@ local bigquery_arg = [
     '--price-gbp-per-kwh-oil',
     '0.0702',
   ] + bigquery_arg),
-  job('03b-%s-bus-policy-high-awareness' % std.extVar('SHORT_SHA'), [
+  job('03c-%s-bus-policy-high-awareness' % std.extVar('SHORT_SHA'), [
     '--intervention',
     'boiler_upgrade_scheme',
     '--heat-pump-awareness',
-    '0.6',
+    '0.5',
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
     '--price-gbp-per-kwh-gas',
@@ -94,7 +98,7 @@ local bigquery_arg = [
     '--gas-oil-boiler-ban-announce-date',
     '2025-01-01',
     '--heat-pump-awareness',
-    '0.6',
+    '0.5',
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
     '--price-gbp-per-kwh-gas',
@@ -114,7 +118,7 @@ local bigquery_arg = [
     '--gas-oil-boiler-ban-announce-date',
     '2030-01-01',
     '--heat-pump-awareness',
-    '0.6',
+    '0.5',
     '--air-source-heat-pump-price-discount-date',
     '2023-01-01:0.3',
     '--price-gbp-per-kwh-gas',
@@ -126,7 +130,7 @@ local bigquery_arg = [
   ] + bigquery_arg),
   job('05-%s-max-industry' % std.extVar('SHORT_SHA'), [
     '--heat-pump-awareness',
-    '0.6',
+    '0.5',
     '--heating-system-hassle-factor',
     '0',
     '--all-agents-heat-pump-suitable',
@@ -145,7 +149,7 @@ local bigquery_arg = [
     '--gas-oil-boiler-ban-date',
     '2030-01-01',
     '--heat-pump-awareness',
-    '0.6',
+    '0.5',
     '--heating-system-hassle-factor',
     '0',
     '--all-agents-heat-pump-suitable',

--- a/k8s/job.jsonnet
+++ b/k8s/job.jsonnet
@@ -47,8 +47,6 @@ local bigquery_arg = [
     '2012-01-01',
     '--steps',
     '120',
-    '--heat-pump-installer-count',
-    '1_800',
      '--heat-pump-installer-annual-growth-rate',
     '0',
   ] + bigquery_arg),

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -122,6 +122,13 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
+        "--heat-pump-installer-count",
+        type=float,
+        default=2_800,
+        help="The number of HP installers at the start of the simulation.",
+    )
+
+    parser.add_argument(
         "--heat-pump-installer-annual-growth-rate",
         type=float,
         default=0.48,
@@ -204,6 +211,7 @@ if __name__ == "__main__":
             args.price_gbp_per_kwh_electricity,
             args.price_gbp_per_kwh_oil,
             args.air_source_heat_pump_price_discount_date,
+            args.heat_pump_installer_count,
             args.heat_pump_installer_annual_growth_rate,
         )
 

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -83,7 +83,7 @@ def parse_args(args=None):
     )
 
     parser.add_argument("--steps", dest="time_steps", type=int, default=156)
-    parser.add_argument("--heat-pump-awareness", type=float, default=0.4)
+    parser.add_argument("--heat-pump-awareness", type=float, default=0.25)
     parser.add_argument("--annual-renovation-rate", type=float, default=0.1)
     parser.add_argument(
         "--household-num-lookahead-years",
@@ -124,8 +124,8 @@ def parse_args(args=None):
     parser.add_argument(
         "--heat-pump-installer-annual-growth-rate",
         type=float,
-        default=0.565,
-        help="The YoY growth rate of heat pump installers across the UK. A value of 0 indicates no growth.",
+        default=0.48,
+        help="The YoY growth rate of heat pump installers across the simulation. A value of 0 indicates no growth.",
     )
 
     def check_string_is_isoformat_datetime(string) -> str:

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -60,8 +60,8 @@ HAZARD_RATE_HEATING_SYSTEM_BETA = 15
 # If a ban is active and has been announced, irrespective of the `SIGMOID_{K, OFFSET}` values,
 # all agents will not consider banned heating systems after this time
 MAX_BAN_LEAD_TIME_YEARS = 10
-SIGMOID_K = 1
-SIGMOID_OFFSET = 7
+SIGMOID_K = 2
+SIGMOID_OFFSET = 0
 
 
 class ConstructionYearBand(enum.Enum):

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -209,13 +209,6 @@ class InterventionType(enum.Enum):
 
 # Source: https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/families/datasets/householdsbytypeofhouseholdandfamilyregionsofenglandandukconstituentcountries
 ENGLAND_WALES_HOUSEHOLD_COUNT_2020 = 24_600_000
-UK_HOUSEHOLD_COUNT = 27_800_000
-
-# Source - https://www.heatpumps.org.uk/wp-content/uploads/2020/06/Building-the-Installer-Base-for-Net-Zero-Heating_02.06.pdf
-# UK figures are proportionally scaled for England + Wales only
-HEAT_PUMP_INSTALLER_COUNT = int(
-    3_200 * (ENGLAND_WALES_HOUSEHOLD_COUNT_2020 / UK_HOUSEHOLD_COUNT)
-)
 
 # Source - https://www.heatpumps.org.uk/wp-content/uploads/2020/06/Building-the-Installer-Base-for-Net-Zero-Heating_02.06.pdf
 # Uses the CCC Balanced Pathway scenario of 625k HPs/year in 2028, stating it requires 33,700 installers - i.e. an installation takes ~19 days

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -11,7 +11,6 @@ from simulation.collectors import get_agent_collectors, get_model_collectors
 from simulation.constants import (
     ENGLAND_WALES_HOUSEHOLD_COUNT_2020,
     HEAT_PUMP_INSTALLATION_DURATION_MONTHS,
-    HEAT_PUMP_INSTALLER_COUNT,
     HEATING_SYSTEM_LIFETIME_YEARS,
     HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR,
     BuiltForm,
@@ -42,6 +41,7 @@ class DomesticHeatingABM(AgentBasedModel):
         air_source_heat_pump_price_discount_schedule: Optional[
             List[Tuple[datetime.datetime, float]]
         ],
+        heat_pump_installer_count: int,
         heat_pump_installer_annual_growth_rate: float,
     ):
         self.start_datetime = start_datetime
@@ -64,6 +64,7 @@ class DomesticHeatingABM(AgentBasedModel):
             if air_source_heat_pump_price_discount_schedule
             else None
         )
+        self.heat_pump_installer_count = heat_pump_installer_count
         self.heat_pump_installer_annual_growth_rate = (
             heat_pump_installer_annual_growth_rate
         )
@@ -86,7 +87,7 @@ class DomesticHeatingABM(AgentBasedModel):
         heat_pump_installers = max(
             int(
                 population_scale_factor
-                * HEAT_PUMP_INSTALLER_COUNT
+                * self.heat_pump_installer_count
                 * (1 + self.heat_pump_installer_annual_growth_rate) ** years_elapsed
             ),
             1,
@@ -223,6 +224,7 @@ def create_and_run_simulation(
     air_source_heat_pump_price_discount_schedule: Optional[
         List[Tuple[datetime.datetime, float]]
     ],
+    heat_pump_installer_count: int,
     heat_pump_installer_annual_growth_rate: float,
 ):
 
@@ -239,6 +241,7 @@ def create_and_run_simulation(
         price_gbp_per_kwh_electricity=price_gbp_per_kwh_electricity,
         price_gbp_per_kwh_oil=price_gbp_per_kwh_oil,
         air_source_heat_pump_price_discount_schedule=air_source_heat_pump_price_discount_schedule,
+        heat_pump_installer_count=heat_pump_installer_count,
         heat_pump_installer_annual_growth_rate=heat_pump_installer_annual_growth_rate,
     )
 

--- a/simulation/tests/common.py
+++ b/simulation/tests/common.py
@@ -53,6 +53,7 @@ def model_factory(**model_attributes):
         "price_gbp_per_kwh_electricity": 0.2006,
         "price_gbp_per_kwh_oil": 0.0482,
         "air_source_heat_pump_price_discount_schedule": None,
+        "heat_pump_installer_count": 2_800,
         "heat_pump_installer_annual_growth_rate": 0,
     }
 


### PR DESCRIPTION
- Refactor the count of heat pump installers at start of simulation, so it's a cl arg instead of a hard-coded constant. This provides us with flexibility over simulations for the historical RHI scenario. Possible adjustments to HP installer count over this historical scenario in a future PR.
- Updates the default HP installer growth rate to `0.48`, a value which reflects the default HP installer initial count of 2_800 experiencing this annual growth over 6 years, to reach 33,700 installers in 2028 (CCC Balanced Pathway scenario)
- Update default HP awareness to a value of `0.25` and "high awareness" scenarios to double that, `0.5`. 25% reflects the proportion of people who know "a lot or a fair amount" about LC heating systems according to the [BEIS Public Attitudes Tracker (Autumn 2021, UK)](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1040726/BEIS_PAT_Autumn_2021_Heat_and_Energy_in_the_Home.pdf)
- Update various scenario labelling
- Updates sigmoid constants to reflect a more conservative response to a ban announcement, that is loosely based upon the historical update of condensing boilers in the context of the non-condensing boiler ban of 2005. 

![image](https://user-images.githubusercontent.com/82801691/152564511-75b144c7-7b13-48b1-b102-bdf5be63bead.png)
