### PR TITLE
Update default start-date of simulation to 2022-01-01

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -70,9 +70,7 @@ def parse_args(args=None):
         "--start-date",
         dest="start_datetime",
         type=convert_to_datetime,
-        default=datetime.datetime.today().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ),
+        default=datetime.datetime(2022, 1, 1),
     )
 
     parser.add_argument(

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -51,11 +51,9 @@ class TestParseArgs:
         args = parse_args([*mandatory_local_args, "--start-date", "2021-01-01"])
         assert args.start_datetime == datetime.datetime(2021, 1, 1)
 
-    def test_start_date_default_is_today_at_midnight(self, mandatory_local_args):
+    def test_start_date_default_is_start_of_2022(self, mandatory_local_args):
         args = parse_args(mandatory_local_args)
-        assert args.start_datetime == datetime.datetime.today().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        assert args.start_datetime == datetime.datetime(2022, 1, 1)
 
     def test_default_seed_is_current_datetime_string(self, mandatory_local_args):
         datetime_before = datetime.datetime.now()


### PR DESCRIPTION
By default, we want to obtain a complete year of simulation results for 2022.