### PR TITLE
Cap household EPC at household's Potential EPC

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -70,9 +70,7 @@ def parse_args(args=None):
         "--start-date",
         dest="start_datetime",
         type=convert_to_datetime,
-        default=datetime.datetime.today().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ),
+        default=datetime.datetime(2022, 1, 1),
     )
 
     parser.add_argument(

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -385,7 +385,9 @@ class Household(Agent):
                 self.windows_energy_efficiency = 5
 
         n_measures = len(insulation_elements)
-        improved_epc_level = min(6, self.epc_rating.value + n_measures)
+        improved_epc_level = min(
+            self.epc_rating.value + n_measures, self.potential_epc_rating.value
+        )
         self.epc_rating = EPCRating(improved_epc_level)
 
     def get_chosen_insulation_costs(self, event_trigger: EventTrigger):

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -200,7 +200,10 @@ class TestHousehold:
     ) -> None:
 
         household = household_factory(
-            roof_energy_efficiency=3, walls_energy_efficiency=2, epc_rating=EPCRating.D
+            roof_energy_efficiency=3,
+            walls_energy_efficiency=2,
+            epc_rating=EPCRating.D,
+            potential_epc_rating=EPCRating.B,
         )
         household.install_insulation_elements({Element.ROOF: 1_000})
 
@@ -212,20 +215,23 @@ class TestHousehold:
         assert household.walls_energy_efficiency == 5
         assert household.epc_rating == EPCRating.B
 
-    def test_impact_of_installing_insulation_measures_is_capped_at_epc_A(
+    @pytest.mark.parametrize("epc", list(EPCRating))
+    def test_impact_of_installing_insulation_measures_is_capped_at_potential_epc(
         self,
+        epc,
     ) -> None:
 
-        epc_A_household = household_factory(
+        household_at_potential_epc = household_factory(
             roof_energy_efficiency=4,
             walls_energy_efficiency=5,
             windows_energy_efficiency=5,
-            epc_rating=EPCRating.A,
+            epc_rating=epc,
+            potential_epc_rating=epc,
         )
-        epc_A_household.install_insulation_elements({Element.ROOF: 1_000})
+        household_at_potential_epc.install_insulation_elements({Element.ROOF: 1_000})
 
-        assert epc_A_household.roof_energy_efficiency == 5
-        assert epc_A_household.epc_rating == EPCRating.A
+        assert household_at_potential_epc.roof_energy_efficiency == 5
+        assert household_at_potential_epc.epc_rating == epc
 
     def test_households_with_potential_epc_below_C_are_not_heat_pump_suitable(
         self,

--- a/simulation/tests/test_main.py
+++ b/simulation/tests/test_main.py
@@ -51,11 +51,9 @@ class TestParseArgs:
         args = parse_args([*mandatory_local_args, "--start-date", "2021-01-01"])
         assert args.start_datetime == datetime.datetime(2021, 1, 1)
 
-    def test_start_date_default_is_today_at_midnight(self, mandatory_local_args):
+    def test_start_date_default_is_start_of_2022(self, mandatory_local_args):
         args = parse_args(mandatory_local_args)
-        assert args.start_datetime == datetime.datetime.today().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
+        assert args.start_datetime == datetime.datetime(2022, 1, 1)
 
     def test_default_seed_is_current_datetime_string(self, mandatory_local_args):
         datetime_before = datetime.datetime.now()


### PR DESCRIPTION
- This PR removes a logical disconnect, whereby households could have EPCs greater than their Potential EPC.
- This is not expected to have an impact upon simulation results, as HP suitability has been derived from the (static)  Potential EPC attribute. Households with a Potential EPC rating worse than C are unable to consider heat pumps as options across all scenarios.