### PR TITLE
Scale the number of new builds to the agent population size

### DIFF
--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -12,7 +12,7 @@ import structlog
 from dateutil.relativedelta import relativedelta
 
 from abm import write_jsonlines
-from simulation.constants import ANNUAL_NEW_BUILDS, InterventionType
+from simulation.constants import ENGLAND_WALES_ANNUAL_NEW_BULDS, InterventionType
 from simulation.model import create_and_run_simulation
 
 structlog.configure(
@@ -217,7 +217,7 @@ if __name__ == "__main__":
             args.air_source_heat_pump_price_discount_date,
             args.heat_pump_installer_count,
             args.heat_pump_installer_annual_growth_rate,
-            ANNUAL_NEW_BUILDS if args.include_new_builds else None,
+            ENGLAND_WALES_ANNUAL_NEW_BULDS if args.include_new_builds else None,
         )
 
         with smart_open.open(args.history_file, "w") as file:

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -221,7 +221,7 @@ HOUSEHOLDS_PER_HEAT_PUMP_INSTALLER_FLOOR = 215
 
 # Source: Element Energy for CCC (pg 33 https://www.theccc.org.uk/wp-content/uploads/2020/12/Element-Energy-Trajectories-for-Residential-Heat-Decarbonisation-Executive-Summary.pdf)
 # Note: These figures have been adjusted to the England/Wales population using ONS data
-ANNUAL_NEW_BUILDS = {
+ENGLAND_WALES_ANNUAL_NEW_BULDS = {
     2021: 45238,
     2022: 62202,
     2023: 73511,

--- a/simulation/model.py
+++ b/simulation/model.py
@@ -125,7 +125,12 @@ class DomesticHeatingABM(AgentBasedModel):
         months_per_step = self.step_interval.months
         years_per_step = months_per_step / 12
         new_builds_in_current_year = self.annual_new_builds.get(current_year, 0)
-        return int(new_builds_in_current_year * years_per_step)
+        population_scale_factor = (
+            self.household_count / ENGLAND_WALES_HOUSEHOLD_COUNT_2020
+        )
+        return int(
+            new_builds_in_current_year * years_per_step * population_scale_factor
+        )
 
     @property
     def heat_pump_installation_capacity_per_step_new_builds(self) -> int:


### PR DESCRIPTION
Added:
* A scaling factor inside the model.new_builds_per_step property that
  scales according to the model.household_count in relation to the
  ENGLAND_WALES_POPULATION. This means that the number of new builds is
  actually scaled to the number of agents we are running

Changed:
* `ANNUAL_NEW_BUILDS` -> `ENGLAND_WALES_ANNUAL_NEW_BUILDS` so its more
  explicit what the constant represents

Note: This has been tested locally, and is exhibiting the behaviour we would expect (see below) and fixes a bug introduced in #119.
![image](https://user-images.githubusercontent.com/30845187/155713665-19d2cafd-8832-4167-bf98-c351c1a584b5.png)
