### PR TITLE
Update model assumptions (EPC upgrade + HP installers)

### DIFF
--- a/k8s/job.jsonnet
+++ b/k8s/job.jsonnet
@@ -6,7 +6,7 @@ local job(name, args_excl_output) = {
     namespace: 'domestic-heating-abm',
   },
   spec: {
-    completions: 30,
+    completions: 10,
     parallelism: 5,
     template: {
       spec: {

--- a/simulation/__main__.py
+++ b/simulation/__main__.py
@@ -129,7 +129,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--heat-pump-installer-count",
         type=float,
-        default=2_800,
+        default=10_800,
         help="The number of HP installers at the start of the simulation.",
     )
 

--- a/simulation/agents.py
+++ b/simulation/agents.py
@@ -333,10 +333,10 @@ class Household(Agent):
                 weights=RENO_NUM_INSULATION_ELEMENTS_UPGRADED.values(),
             )[0]
 
-        if event_trigger == EventTrigger.EPC_C_UPGRADE:
+        if event_trigger == EventTrigger.EPC_D_UPGRADE:
             # The number of insulation elements a household would require to reach epc_rating C
             # We assume each insulation measure will contribute +1 EPC grade
-            return max(0, EPCRating.C.value - self.epc_rating.value)
+            return max(0, EPCRating.D.value - self.epc_rating.value)
 
         return 0
 
@@ -636,7 +636,7 @@ class Household(Agent):
                     model, event_trigger=EventTrigger.RENOVATION
                 )
             chosen_insulation_costs = self.get_chosen_insulation_costs(
-                event_trigger=EventTrigger.EPC_C_UPGRADE
+                event_trigger=EventTrigger.EPC_D_UPGRADE
             )
 
             costs_unit_and_install = {}

--- a/simulation/constants.py
+++ b/simulation/constants.py
@@ -119,7 +119,7 @@ DISCOUNT_RATE_WEIBULL_BETA = 0.165
 class EventTrigger(enum.Enum):
     BREAKDOWN = 0
     RENOVATION = 1
-    EPC_C_UPGRADE = 2
+    EPC_D_UPGRADE = 2
 
 
 # Scale factor is inferred from general relationship between estimated floor area and kW capacity

--- a/simulation/tests/test_agents.py
+++ b/simulation/tests/test_agents.py
@@ -161,18 +161,18 @@ class TestHousehold:
     ) -> None:
 
         household = household_factory(epc_rating=epc_rating)
-        if household.epc_rating.value < EPCRating.C.value:
-            expected_insulation_elements = EPCRating.C.value - epc_rating.value
+        if household.epc_rating.value < EPCRating.D.value:
+            expected_insulation_elements = EPCRating.D.value - epc_rating.value
             assert (
                 household.get_num_insulation_elements(
-                    event_trigger=EventTrigger.EPC_C_UPGRADE
+                    event_trigger=EventTrigger.EPC_D_UPGRADE
                 )
                 == expected_insulation_elements
             )
-        if household.epc_rating.value >= EPCRating.C.value:
+        if household.epc_rating.value >= EPCRating.D.value:
             assert (
                 household.get_num_insulation_elements(
-                    event_trigger=EventTrigger.EPC_C_UPGRADE
+                    event_trigger=EventTrigger.EPC_D_UPGRADE
                 )
                 == 0
             )
@@ -453,24 +453,24 @@ class TestHousehold:
         )
 
     @pytest.mark.parametrize("epc_rating", list(EPCRating))
-    def test_household_chooses_insulation_elements_at_epc_C_upgrade_event_if_current_epc_worse_than_C(
+    def test_household_chooses_insulation_elements_at_epc_D_upgrade_event_if_current_epc_worse_than_C(
         self,
         epc_rating,
     ) -> None:
 
         household = household_factory(epc_rating=epc_rating)
 
-        if epc_rating.value >= EPCRating.C.value:
+        if epc_rating.value >= EPCRating.D.value:
             assert (
                 household.get_chosen_insulation_costs(
-                    event_trigger=EventTrigger.EPC_C_UPGRADE
+                    event_trigger=EventTrigger.EPC_D_UPGRADE
                 )
                 == {}
             )
 
-        if epc_rating.value < EPCRating.C.value:
+        if epc_rating.value < EPCRating.D.value:
             chosen_insulation_elements = household.get_chosen_insulation_costs(
-                event_trigger=EventTrigger.EPC_C_UPGRADE
+                event_trigger=EventTrigger.EPC_D_UPGRADE
             )
 
             assert chosen_insulation_elements


### PR DESCRIPTION
* Assume that households upgrade to EPC D when they install a HP. 
* Update the initial number of HP installers based on latest data