### PR TITLE
Update BUS funding cap

### DIFF
--- a/simulation/costs.py
+++ b/simulation/costs.py
@@ -312,7 +312,7 @@ def estimate_boiler_upgrade_scheme_grant(
         return 0
 
     model_population_scale = ENGLAND_WALES_HOUSEHOLD_COUNT_2020 / model.household_count
-    boiler_upgrade_funding_cap_gbp = 450_000_000 / model_population_scale
+    boiler_upgrade_funding_cap_gbp = 237_500_000 / model_population_scale
     if (
         model.boiler_upgrade_scheme_cumulative_spend_gbp
         >= boiler_upgrade_funding_cap_gbp
@@ -345,7 +345,7 @@ def estimate_extended_boiler_upgrade_scheme_grant(
         return 0
 
     model_population_scale = ENGLAND_WALES_HOUSEHOLD_COUNT_2020 / model.household_count
-    boiler_upgrade_funding_cap_gbp = 1_650_000_000 / model_population_scale
+    boiler_upgrade_funding_cap_gbp = 5_400_000_000 / model_population_scale
     if (
         model.boiler_upgrade_scheme_cumulative_spend_gbp
         >= boiler_upgrade_funding_cap_gbp

--- a/simulation/tests/test_costs.py
+++ b/simulation/tests/test_costs.py
@@ -227,7 +227,7 @@ class TestCosts:
         model_population_scale = (
             ENGLAND_WALES_HOUSEHOLD_COUNT_2020 / model.household_count
         )
-        boiler_upgrade_scheme_budget_scaled = 450_000_000 / model_population_scale
+        boiler_upgrade_scheme_budget_scaled = 237_500_000 / model_population_scale
 
         model.boiler_upgrade_scheme_cumulative_spend_gbp = (
             boiler_upgrade_scheme_budget_scaled * 0.8
@@ -338,7 +338,7 @@ class TestCosts:
         model_population_scale = (
             ENGLAND_WALES_HOUSEHOLD_COUNT_2020 / model.household_count
         )
-        boiler_upgrade_scheme_budget_scaled = 1_650_000_000 / model_population_scale
+        boiler_upgrade_scheme_budget_scaled = 5_400_000_000 / model_population_scale
 
         model.boiler_upgrade_scheme_cumulative_spend_gbp = (
             boiler_upgrade_scheme_budget_scaled * 0.8


### PR DESCRIPTION
Update BUS funding cap:
* 'Standard BUS': £237.5M until 2028. --> BUS horizon is 1 Jan 2024 (beginning of simulation) - Apr2025. Assuming £200M Apr 2024-2025 (see [announcement](https://www.gov.uk/government/publications/boiler-upgrade-scheme-approval-to-over-allocate-vouchers/approval-to-over-allocate-vouchers-for-the-boiler-upgrade-scheme-october-2024)) + £37.5M Jan-Apr 2024 given that we assume 2024 had a £150M funding cap.
* 'Extended BUS': £5.45B until 2035 --> Assuming £250M 2024-’25 + £1.54B 2025-’28 (see [announcement](https://www.gov.uk/government/news/families-business-and-industry-to-get-energy-efficiency-support)) + £515M PA 2028-2035.